### PR TITLE
chore: add contribution workflow and CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,94 @@
+name: Bug report
+description: Something behaves differently than documented
+labels: ["type:bug", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most bugs in a shell extension are reproducible in seconds **if** the
+        report says which GNOME, which monitors, and what the journal said.
+        Without those three, a maintainer is guessing.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you got instead.
+      placeholder: |
+        1. Focused a window on my second monitor
+        2. Pressed Super+Alt+2
+        3. Expected the second workspace; the screen went blank instead
+    validations:
+      required: true
+
+  - type: input
+    id: gnome-version
+    attributes:
+      label: GNOME Shell version
+      description: "`gnome-shell --version`"
+      placeholder: "GNOME Shell 50.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: session
+    attributes:
+      label: Session type
+      description: "`echo $XDG_SESSION_TYPE`"
+      options:
+        - Wayland
+        - X11
+    validations:
+      required: true
+
+  - type: textarea
+    id: monitors
+    attributes:
+      label: Monitor setup
+      description: >
+        How many monitors, which is primary, and their orientation. This
+        extension only acts on non-primary monitors, so the layout is often
+        the whole answer.
+      placeholder: "Two: 1920x1080 primary, 1080x1920 portrait on the right (secondary)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Journal output
+      description: >
+        Turn on **Debug logging** in preferences, reproduce the problem, then
+        paste the output. Errors matter even when they mention other extensions.
+      value: |
+        <details><summary>journalctl</summary>
+
+        ```
+        # journalctl -f -o cat /usr/bin/gnome-shell | grep -Ei 'workspace-islands|JS ERROR'
+        ```
+
+        </details>
+    validations:
+      required: true
+
+  - type: input
+    id: extensions
+    attributes:
+      label: Other enabled extensions
+      description: "`gnome-extensions list --enabled`"
+      placeholder: "Vitals@CoreCoding.com, clipboard-history@alexsaveau.dev"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: preconditions
+    attributes:
+      label: Preconditions
+      description: "`make doctor` checks all of these at once."
+      options:
+        - label: "`workspaces-only-on-primary` is `true`"
+          required: true
+        - label: PaperWM is not enabled
+          required: true
+        - label: I still see the problem with **Slide animation** turned off
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question about using it
+    url: https://github.com/danielbernalo/gnome-workspace-islands/discussions
+    about: Not sure whether something is a bug? Ask here first.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,63 @@
+name: Proposal
+description: Argue for a change to how this behaves
+labels: ["type:feature", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A good proposal is mostly about the problem. If the problem is clear
+        and real, the solution is usually easy to argue about — and sometimes
+        turns out to be something nobody had thought of.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: >
+        What are you trying to do, and what stops you today? Describe the
+        situation, not the feature you have in mind.
+      placeholder: >
+        When I unplug my laptop at the end of the day, every window from the
+        external monitor piles onto the built-in screen and I lose the layout.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you propose
+      description: What should happen instead, concretely enough to disagree with.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you considered and rejected
+      description: >
+        Existing settings, other extensions, a different shape of the same
+        idea. This is the most useful section in the form — it is what stops a
+        discussion from re-treading ground you already covered.
+    validations:
+      required: true
+
+  - type: textarea
+    id: cost
+    attributes:
+      label: What it might cost
+      description: >
+        Optional, and valued. Who might not want this? What could it break or
+        make slower? A proposal that names its own downside gets taken more
+        seriously, not less.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      options:
+        - label: >
+            I have read **Deliberately not built** in the README and this is
+            not one of those, or I am arguing that the reasoning has changed
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+Closes #
+
+## Type
+
+<!-- Exactly one, and add the matching type:* label. -->
+
+- [ ] Bug fix — `type:bug`
+- [ ] New feature — `type:feature`
+- [ ] Documentation only — `type:docs`
+- [ ] Refactoring — `type:refactor`
+- [ ] Maintenance or tooling — `type:chore`
+- [ ] Breaking change — `type:breaking-change`
+
+## What this does
+
+<!-- One to three bullets. What changes for a user, not which files moved. -->
+
+-
+
+## Changes
+
+| File | Change |
+| --- | --- |
+|  |  |
+
+## How it was verified
+
+<!-- This extension has no automated tests. Say what you actually did. -->
+
+- [ ] `make doctor` passes
+- [ ] Tested in a real session (logged out and back in — a running shell
+      caches modules and will not pick up edits)
+- [ ] Tested with more than one monitor
+- [ ] Disabled and re-enabled the extension: no windows left minimized, no
+      leftover panel widgets, nothing patched still patched
+
+## Shell internals
+
+<!-- Delete if untouched. -->
+
+<!--
+If this patches, overrides or replaces anything in GNOME Shell, name it here
+and say what happens when that seam moves in a future release. Every existing
+one is documented in code with the same reasoning; a new one should be too.
+-->
+
+## Checklist
+
+- [ ] Linked an issue above
+- [ ] Exactly one `type:*` label
+- [ ] Conventional commit messages
+- [ ] README updated if behaviour changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    name: Static checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install GLib tools
+        run: sudo apt-get update && sudo apt-get install -y libglib2.0-bin
+
+      # gjs cannot parse files importing resource:/// outside a running shell,
+      # and there is no gjs on a runner anyway. Node parses the same syntax.
+      - name: Every module parses
+        run: |
+          fail=0
+          for f in src/*.js; do
+            cp "$f" "/tmp/$(basename "${f%.js}").mjs"
+            node --check "/tmp/$(basename "${f%.js}").mjs" || fail=1
+          done
+          exit $fail
+
+      - name: Schema compiles
+        run: glib-compile-schemas --strict --dry-run src/schemas
+
+      # Renaming the extension touches the uuid, the schema id, the schema
+      # filename and metadata.json independently. Drift between them fails at
+      # enable() time on a user's machine, which is the worst place to find out.
+      - name: Metadata agrees with the schema
+        run: |
+          python3 - <<'EOF'
+          import json, pathlib, re, sys
+
+          meta = json.loads(pathlib.Path('src/metadata.json').read_text())
+          schemas = list(pathlib.Path('src/schemas').glob('*.gschema.xml'))
+
+          if len(schemas) != 1:
+              sys.exit(f'expected exactly one schema, found {len(schemas)}')
+
+          declared = meta['settings-schema']
+          defined = re.search(r'<schema id="([^"]+)"', schemas[0].read_text()).group(1)
+
+          if declared != defined:
+              sys.exit(f'metadata declares {declared!r}, schema defines {defined!r}')
+
+          if schemas[0].name != f'{defined}.gschema.xml':
+              sys.exit(f'schema id {defined!r} does not match filename {schemas[0].name!r}')
+
+          print(f'ok: {defined}')
+          EOF
+
+      # A module renamed but not updated at its import site throws on load and
+      # nowhere earlier.
+      - name: Every relative import resolves
+        run: |
+          python3 - <<'EOF'
+          import pathlib, re, sys
+
+          missing = []
+          for path in pathlib.Path('src').glob('*.js'):
+              for imported in re.findall(r"from '(\./[^']+)'", path.read_text()):
+                  if not (path.parent / imported).exists():
+                      missing.append(f'{path}: {imported}')
+
+          if missing:
+              sys.exit('unresolved imports:\n  ' + '\n  '.join(missing))
+
+          print('ok')
+          EOF
+
+      # `gnome-extensions pack` ships only extension.js, prefs.js, metadata.json,
+      # stylesheet.css and schemas/. Everything else needs --extra-source, and it
+      # warns about none of them — the bundle just throws on first import.
+      - name: Bundle would include every module
+        run: |
+          python3 - <<'EOF'
+          import pathlib, re, subprocess, sys
+
+          makefile = pathlib.Path('Makefile').read_text()
+          if '--extra-source' not in makefile:
+              sys.exit('pack target no longer passes --extra-source')
+
+          listed = subprocess.run(
+              ['make', '-s', 'print-extra-sources'],
+              capture_output=True, text=True, check=True).stdout.split()
+
+          expected = {p.name for p in pathlib.Path('src').glob('*.js')}
+          expected -= {'extension.js', 'prefs.js'}
+
+          if set(listed) != expected:
+              sys.exit(f'pack would miss: {sorted(expected - set(listed))}')
+
+          print(f'ok: {len(listed)} extra modules')
+          EOF

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers by opening an issue or contacting them directly.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,101 @@
+# Contributing
+
+Thanks for looking. This is a young project — the most valuable thing you can
+send right now is a good bug report.
+
+## Reporting a bug
+
+Open a [bug report](../../issues/new?template=bug_report.yml). The form asks
+for GNOME version, session type, monitor layout and journal output because
+without those three a maintainer is guessing, and guessing at a shell
+extension usually means asking you to run things for a week.
+
+Run `make doctor` first — it checks every precondition at once and rules out
+the common causes in one command.
+
+## Proposing a change
+
+Open a [proposal](../../issues/new?template=feature_request.yml). The form
+leads with the problem rather than the solution on purpose: a clearly stated
+problem often has a better answer than the one either of us walked in with.
+
+Read **Deliberately not built** in the README first. Some things were left out
+for reasons that are written down; if you think a reason has stopped being
+true, say so — that is a fine proposal.
+
+## Sending code
+
+**Open an issue first.** Not bureaucracy: this extension patches GNOME Shell
+internals, and whether a change is a good idea usually depends on which seam it
+lands on. Ten minutes in an issue can save an afternoon in a branch.
+
+```bash
+git checkout -b fix/short-description main
+```
+
+Branch names are `type/description` — `feat`, `fix`, `chore`, `docs`,
+`refactor`, `perf`, `test`, `build`, `ci`, `revert` — lowercase, no spaces.
+
+Commits follow [Conventional Commits](https://www.conventionalcommits.org):
+
+```
+fix(indicator): render the panel workspace dots
+feat(overview): drag windows between virtual workspaces
+docs: rewrite the README for people who want to use this
+```
+
+One commit per unit of work — something a reviewer can understand, and you can
+revert, on its own. Not one commit per file type.
+
+Then open a PR against `main` and add exactly one `type:*` label.
+
+## Developing
+
+```bash
+make install   # symlink src/ into the extensions dir — edits apply live
+make doctor    # check every precondition; run this first when something is off
+make nested    # launch a nested session for testing
+make logs      # follow gnome-shell logs
+make pack      # build the installable bundle
+```
+
+Three things that cost time if you do not know them:
+
+- **GJS caches ES modules for the life of the process.** Editing a file changes
+  nothing in a running shell — not even if you toggle the extension off and on.
+  You need a fresh shell every time.
+- **Wayland has no `Alt+F2 → r`.** Test in `make nested`, then log out and back
+  in for a real session.
+- **`make install` and `make pack` are different installs.** The first
+  symlinks, so edits apply live; the second installs a copy, so they do not.
+  `make doctor` tells you which one you have.
+
+There are no automated tests. What CI checks is that every module parses, the
+schema compiles, metadata and schema agree, imports resolve, and the bundle
+would contain every module. All five exist because each caught a real bug
+during development. Everything about behaviour is verified by hand — say what
+you did in the PR.
+
+## Touching GNOME Shell internals
+
+Most of this extension's risk lives in a handful of places where it patches,
+overrides or replaces something private in GNOME Shell. Those are listed at the
+top of `src/overview.js` and `src/slide.js`, each with the reasoning for why
+that seam and not another.
+
+If you add one:
+
+- Say in a comment **why that seam**, and what happens when it moves.
+- Degrade rather than throw. A missing method should cost a feature, not the
+  session.
+- Undo it in `disable()`. Anything left patched after unload is a bug that
+  outlives the extension.
+
+Two traps already documented in code, worth knowing before you spend a day on
+either: a handler connected with `.bind(this)` in a constructor cannot be
+overridden afterwards, and a disabled `SwipeTracker` is the only way to stop the
+shell's own gestures from swallowing events.
+
+## Code of Conduct
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/Makefile
+++ b/Makefile
@@ -122,3 +122,6 @@ z=zipfile.ZipFile('$(CURDIR)/$(UUID).shell-extension.zip'); \
 missing=[f for f in '$(notdir $(wildcard $(SRC)/*.js))'.split() if f not in z.namelist()]; \
 sys.exit('MISSING FROM BUNDLE: '+', '.join(missing)) if missing else \
 print('  %d js modules bundled' % len([n for n in z.namelist() if n.endswith('.js')]))"
+
+print-extra-sources:
+	@echo $(EXTRA_SOURCES)


### PR DESCRIPTION
Closes #1

## Type

- [x] Maintenance or tooling — `type:chore`

## What this does

- Issue forms that require what a maintainer needs to reproduce, and a proposal form that leads with the problem instead of the solution
- `CONTRIBUTING.md` and a PR template built around the fact that this project has no behavioural tests and patches shell internals
- CI whose five checks each come from a bug that actually shipped

## Changes

| File | Change |
| --- | --- |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Requires GNOME version, session type, monitor layout, journal output, other extensions |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Problem first; requires what was considered and rejected |
| `.github/ISSUE_TEMPLATE/config.yml` | Blank issues off, Discussions for questions |
| `.github/PULL_REQUEST_TEMPLATE.md` | Verification is manual, so it asks what was done; separate section for shell internals |
| `.github/workflows/ci.yml` | Parse, schema, metadata/schema agreement, import resolution, bundle completeness |
| `CONTRIBUTING.md` | Development loop, commit convention, and the two traps that each cost a day |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 |
| `Makefile` | `print-extra-sources`, so CI can verify the bundle without a GNOME session |

## How it was verified

- [x] `make doctor` passes
- [x] `make -s print-extra-sources` lists all 10 non-default modules
- [x] Every CI check run locally against this tree
- [ ] CI observed green on this PR — that is what this PR is for

## Shell internals

None touched.

## Checklist

- [x] Linked an issue above
- [x] Exactly one `type:*` label
- [x] Conventional commit messages
- [x] README updated if behaviour changed — no behaviour changed