### PR TITLE
chore: prepare the extension for publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,20 @@ jobs:
           if schemas[0].name != f'{defined}.gschema.xml':
               sys.exit(f'schema id {defined!r} does not match filename {schemas[0].name!r}')
 
-          print(f'ok: {defined}')
+          # The guide is explicit: `version` SHOULD NOT be set by developers.
+          # extensions.gnome.org overrides it, and with it set GNOME Shell may
+          # upgrade or downgrade the extension on its own.
+          if 'version' in meta:
+              sys.exit('metadata.json must not set "version" — use "version-name"')
+
+          name = meta.get('version-name')
+          if not name:
+              sys.exit('metadata.json is missing "version-name"')
+
+          if not re.fullmatch(r'(?!^[. ]+$)[a-zA-Z0-9 .]{1,16}', name):
+              sys.exit(f'version-name {name!r} fails the documented pattern')
+
+          print(f'ok: {defined} @ {name}')
           EOF
 
       # A module renamed but not updated at its import site throws on load and
@@ -78,27 +91,8 @@ jobs:
           print('ok')
           EOF
 
-      # `gnome-extensions pack` ships only extension.js, prefs.js, metadata.json,
-      # stylesheet.css and schemas/. Everything else needs --extra-source, and it
-      # warns about none of them — the bundle just throws on first import.
-      - name: Bundle would include every module
-        run: |
-          python3 - <<'EOF'
-          import pathlib, re, subprocess, sys
-
-          makefile = pathlib.Path('Makefile').read_text()
-          if '--extra-source' not in makefile:
-              sys.exit('pack target no longer passes --extra-source')
-
-          listed = subprocess.run(
-              ['make', '-s', 'print-extra-sources'],
-              capture_output=True, text=True, check=True).stdout.split()
-
-          expected = {p.name for p in pathlib.Path('src').glob('*.js')}
-          expected -= {'extension.js', 'prefs.js'}
-
-          if set(listed) != expected:
-              sys.exit(f'pack would miss: {sorted(expected - set(listed))}')
-
-          print(f'ok: {len(listed)} extra modules')
-          EOF
+      # The pack target asserts that every module made it into the archive.
+      # It once shipped 2 of 12, because `gnome-extensions pack` drops whatever
+      # is not named with --extra-source and warns about none of it.
+      - name: Bundle builds and is complete
+        run: make pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install GLib tools
+        run: sudo apt-get update && sudo apt-get install -y libglib2.0-bin
+
+      # A tag that disagrees with the metadata would ship an archive claiming a
+      # version nobody released. Cheaper to fail here than to yank a release.
+      - name: Tag matches version-name
+        run: |
+          python3 - <<'EOF'
+          import json, os, pathlib, sys
+
+          tag = os.environ['GITHUB_REF_NAME']
+          declared = json.loads(pathlib.Path('src/metadata.json').read_text())['version-name']
+
+          if tag != f'v{declared}':
+              sys.exit(f'tag {tag!r} does not match version-name {declared!r} (expected v{declared})')
+
+          print(f'ok: {tag}')
+          EOF
+
+      - name: Build the bundle
+        run: make pack
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          uuid=$(python3 -c "import json;print(json.load(open('src/metadata.json'))['uuid'])")
+
+          gh release create "$GITHUB_REF_NAME" \
+            "$uuid.shell-extension.zip" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --notes-start-tag "$(git describe --tags --abbrev=0 "$GITHUB_REF_NAME^" 2>/dev/null || echo '')" \
+            --notes "$(cat <<'NOTES'
+## Install
+
+Download the `.zip` below, then:
+
+```bash
+gnome-extensions install --force workspace-islands@danielbernalo.github.io.shell-extension.zip
+gnome-extensions enable workspace-islands@danielbernalo.github.io
+```
+
+Then **log out and back in** — Wayland cannot reload the shell in place.
+
+Check it came up:
+
+```bash
+gnome-extensions info workspace-islands@danielbernalo.github.io   # State: ACTIVE
+```
+
+Requires GNOME Shell 50 on Wayland, at least two monitors, and
+`workspaces-only-on-primary` set to `true`. See the README for the full list.
+
+---
+NOTES
+)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ Then open a PR against `main` and add exactly one `type:*` label.
 ## Developing
 
 ```bash
+make skills    # fetch the agent skills pinned in skills-lock.json
 make install   # symlink src/ into the extensions dir — edits apply live
 make doctor    # check every precondition; run this first when something is off
 make nested    # launch a nested session for testing
@@ -69,6 +70,14 @@ Three things that cost time if you do not know them:
 - **`make install` and `make pack` are different installs.** The first
   symlinks, so edits apply live; the second installs a copy, so they do not.
   `make doctor` tells you which one you have.
+
+`.agents/` and `.claude/` are not in the repository. The skill under them comes
+from a public repo that declares no licence, and with no licence the default is
+all rights reserved — redistributing it inside a GPL project is not something to
+do casually. `skills-lock.json` pins the source and the exact commit instead, and
+`make skills` fetches it, checks the hash, and re-applies one local patch:
+upstream links its own reference files through absolute `file:///` paths under
+the author's home directory, which resolve on exactly one machine.
 
 There are no automated tests. What CI checks is that every module parses, the
 schema compiles, metadata and schema agree, imports resolve, and the bundle

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,33 @@ would contain every module. All five exist because each caught a real bug
 during development. Everything about behaviour is verified by hand — say what
 you did in the PR.
 
+## Cutting a release
+
+`version` is deliberately absent from `metadata.json`. The
+[official guide](https://gjs.guide/extensions/overview/anatomy.html) is
+explicit that extension developers should not set it: the extensions website
+overrides it, and with it set GNOME Shell may upgrade or downgrade the
+extension on its own. The human-facing string lives in `version-name`.
+
+To release:
+
+1. Bump `version-name` in `src/metadata.json` — 1 to 16 characters, letters,
+   digits, spaces and periods only.
+2. Commit it.
+3. Tag it `v<version-name>` and push the tag.
+
+```bash
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+CI builds the bundle and publishes it. It refuses to publish when the tag and
+`version-name` disagree, so a release can never claim a version nothing was
+tagged with.
+
+`make pack` is deterministic — fixed timestamps, sorted entries — so anyone can
+rebuild a tag and compare bytes with what was published.
+
 ## Touching GNOME Shell internals
 
 Most of this extension's risk lives in a handful of places where it patches,

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,90 @@ help:
 	@echo "make logs       follow gnome-shell logs"
 	@echo "make status     show install + enable state"
 
+# Agent skills are fetched, not vendored.
+#
+# `.agents/` is gitignored on purpose: the skill under it comes from
+# tazztone/skills-server, which is public but declares no licence — and with no
+# licence the default is all rights reserved, so redistributing it inside a
+# GPL repository is not something to do casually. The lockfile records where it
+# came from and at which commit; this target brings it back.
+#
+# It also re-applies one local patch. Upstream links its own reference files
+# through absolute file:/// paths under the author's home directory, which
+# resolve on exactly one machine.
+skills:
+	@python3 -c "$$SKILLS_SCRIPT"
+
+define SKILLS_SCRIPT
+import hashlib, io, json, pathlib, re, sys, tarfile, urllib.request
+
+root = pathlib.Path('$(CURDIR)')
+lock = json.loads((root / 'skills-lock.json').read_text())
+
+for name, entry in lock['skills'].items():
+    repo, ref = entry['source'], entry['ref']
+    inner = str(pathlib.PurePosixPath(entry['skillPath']).parent)
+
+    print('  %s <- %s@%s' % (name, repo, ref[:8]))
+
+    url = 'https://codeload.github.com/%s/tar.gz/%s' % (repo, ref)
+    with urllib.request.urlopen(url) as response:
+        blob = response.read()
+
+    target = root / '.agents' / 'skills' / name
+    extracted = 0
+
+    with tarfile.open(fileobj=io.BytesIO(blob)) as tar:
+        for member in tar.getmembers():
+            parts = pathlib.PurePosixPath(member.name).parts[1:]
+            prefix = pathlib.PurePosixPath(inner).parts
+
+            if not member.isfile() or parts[:len(prefix)] != prefix:
+                continue
+
+            out = target.joinpath(*parts[len(prefix):])
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(tar.extractfile(member).read())
+            extracted += 1
+
+    if not extracted:
+        raise SystemExit('  nothing matched %s in the archive' % inner)
+
+    skill = target / 'SKILL.md'
+    digest = hashlib.sha256(skill.read_bytes()).hexdigest()
+
+    if digest != entry['computedHash']:
+        raise SystemExit(
+            '  hash mismatch: locked %s, got %s\n'
+            '  upstream moved under the pinned ref, which should not happen'
+            % (entry['computedHash'][:12], digest[:12]))
+
+    # Re-apply the local patch. See "patched" in skills-lock.json.
+    text = skill.read_text()
+    before = text.count('file:///')
+    text = re.sub(r'file:///\S*?/skills/%s/references/' % name, 'references/', text)
+
+    note = ('<!--\n'
+            'Locally patched by `make skills`: upstream links its own reference\n'
+            'files through absolute file:/// paths under the author home directory,\n'
+            'which resolve on exactly one machine. Rewritten relative to this file.\n'
+            '-->\n\n')
+
+    if 'Locally patched' not in text:
+        text = text.replace('# GNOME Shell Extensions', note + '# GNOME Shell Extensions', 1)
+
+    skill.write_text(text)
+
+    link = root / '.claude' / 'skills' / name
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if link.is_symlink() or link.exists():
+        link.unlink()
+    link.symlink_to(pathlib.Path('../../.agents/skills') / name)
+
+    print('  %d files, hash verified, %d absolute links rewritten' % (extracted, before))
+endef
+export SKILLS_SCRIPT
+
 schemas:
 	glib-compile-schemas $(SRC)/schemas
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ UUID    := workspace-islands@danielbernalo.github.io
 SRC     := $(CURDIR)/src
 TARGET  := $(HOME)/.local/share/gnome-shell/extensions/$(UUID)
 
-.PHONY: help schemas install uninstall enable disable doctor pack nested logs status
+.PHONY: help schemas skills install uninstall enable disable doctor pack nested logs status
 
 help:
 	@echo "make doctor     check every precondition — run this first when something's off"
+	@echo "make skills     fetch agent skills pinned in skills-lock.json"
 	@echo "make schemas    compile gsettings schemas"
 	@echo "make install    compile schemas + symlink src/ into GNOME's extension dir"
 	@echo "make enable     add the uuid to enabled-extensions (linking is not enabling)"
@@ -104,24 +105,51 @@ doctor:
 	@echo "Note: gsettings may report schema defaults instead of real values."
 	@echo "      dconf is the source of truth."
 
-# `gnome-extensions pack` ships extension.js, prefs.js, metadata.json,
-# stylesheet.css and schemas/ — and nothing else. Every other module has to be
-# named with --extra-source. It does not warn about the ones you forget; it
-# produces a bundle that throws on the first import instead.
+# The bundle is a flat zip: every module at the root, schemas/ holding only the
+# XML — the shell compiles it at install time — plus the licence, because what
+# a user downloads should carry the terms it ships under.
 #
-# Computed from the directory rather than listed, so a module added later
-# cannot be silently left out of a release.
-EXTRA_SOURCES := $(filter-out extension.js prefs.js,$(notdir $(wildcard $(SRC)/*.js)))
-
+# Built with python rather than `gnome-extensions pack` or `zip`. The first
+# lives in the gnome-shell package, so a CI runner would have to install a
+# desktop to produce an archive; the second is simply absent on plenty of
+# machines, which is how this target was broken before. python3 is already a
+# dependency of the targets above.
+#
+# Deterministic on purpose: fixed timestamps and sorted entries, so the same
+# tree always produces the same bytes and a release can be reproduced.
 pack: schemas
-	@cd $(SRC) && gnome-extensions pack --force -o $(CURDIR) \
-	  $(foreach f,$(EXTRA_SOURCES),--extra-source=$(f)) .
-	@echo "packed $(UUID).shell-extension.zip"
-	@python3 -c "import zipfile,sys; \
-z=zipfile.ZipFile('$(CURDIR)/$(UUID).shell-extension.zip'); \
-missing=[f for f in '$(notdir $(wildcard $(SRC)/*.js))'.split() if f not in z.namelist()]; \
-sys.exit('MISSING FROM BUNDLE: '+', '.join(missing)) if missing else \
-print('  %d js modules bundled' % len([n for n in z.namelist() if n.endswith('.js')]))"
+	@python3 -c "$$PACK_SCRIPT"
 
-print-extra-sources:
-	@echo $(EXTRA_SOURCES)
+define PACK_SCRIPT
+import pathlib, zipfile
+
+root = pathlib.Path('$(CURDIR)')
+src = root / 'src'
+out = root / '$(UUID).shell-extension.zip'
+
+members = sorted(
+    p for p in src.rglob('*')
+    if p.is_file() and p.name != 'gschemas.compiled')
+
+with zipfile.ZipFile(out, 'w', zipfile.ZIP_DEFLATED) as z:
+    for path in members:
+        info = zipfile.ZipInfo(str(path.relative_to(src)), (1980, 1, 1, 0, 0, 0))
+        info.compress_type = zipfile.ZIP_DEFLATED
+        info.external_attr = 0o644 << 16
+        z.writestr(info, path.read_bytes())
+
+    licence = zipfile.ZipInfo('LICENSE', (1980, 1, 1, 0, 0, 0))
+    licence.compress_type = zipfile.ZIP_DEFLATED
+    licence.external_attr = 0o644 << 16
+    z.writestr(licence, (root / 'LICENSE').read_bytes())
+
+modules = {p.name for p in src.glob('*.js')}
+packed = set(z.namelist())
+missing = sorted(modules - packed)
+if missing:
+    raise SystemExit('MISSING FROM BUNDLE: ' + ', '.join(missing))
+
+print('  packed %s' % out.name)
+print('  %d js modules, %d files' % (len(modules), len(packed)))
+endef
+export PACK_SCRIPT

--- a/README.md
+++ b/README.md
@@ -215,36 +215,6 @@ Super+1..4, untouched        Map<index, Set<window>>
                              switch = show set B, hide set A
 ```
 
-### Why minimize, and not something subtler
-
-Everything rests on how a window is made to stop being visible. Two candidates were built side by side and compared under real use:
-
-| | `actor-hide` | `minimize` ✅ chosen |
-| --- | --- | --- |
-| Visual | Instant, no animation | Minimize animation |
-| Window state | Untouched | Mutter knows it is minimized |
-| Focus | Must be handled manually | Handled by the WM |
-| Survives a native workspace switch | **No — gets overwritten** | **Yes** |
-| Risk | Inconsistent state on a crash | Lower |
-
-**`actor-hide` is overwritten by native workspace switches.** A switch walks the window actors and shows those belonging to the incoming workspace. Sticky windows belong to *every* workspace, so Mutter showed all of them and every virtual workspace landed on screen at once.
-
-That could be worked around by reasserting visibility one frame later — but that is a race against the shell, not a fix.
-
-`minimize` is structurally immune. Minimized state is real window state, not a flag Mutter recomputes, so a workspace switch leaves it alone. No race to lose, and focus handover comes free because the window manager already knows a minimized window cannot hold focus.
-
-The cost is the minimize animation and the marker in the dash. Both were judged acceptable; the race was not.
-
-### Where it touches GNOME
-
-Five shell seams, all in `src/overview.js` and `src/slide.js` on purpose: when a GNOME update breaks this extension, those are the files to open.
-
-The two that cost the most to discover:
-
-**A second swipe tracker can never work.** `TouchpadSwipeGesture` claims every three-finger swipe on orientation alone, knows nothing about monitors, and returns `EVENT_STOP` even when its owner declined the gesture. And overriding the handlers does not work either: they are connected with `.bind(this)` at construction, which captures the original function before any extension exists — the override installs, reports success, and is never called. The shell's tracker is disabled and replaced instead.
-
-**GNOME's workspace thumbnails deliberately omit minimized windows** (`_isOverviewWindow` requires `showing_on_its_workspace()`), which here would be every window on every inactive workspace. A faithful copy would render identical empty rectangles. The strip uses `Shell.WindowPreviewLayout` — the C layout `WindowPreview` builds on, which paints the window texture rather than cloning a possibly unmapped actor.
-
 ### Layout
 
 ```
@@ -263,6 +233,182 @@ src/
 ├── prefs.js          GTK4/Adwaita preferences (separate process)
 └── schemas/          gsettings schema
 ```
+
+## Questions this design invites
+
+Anyone reading the source — a reviewer, or you in six months — will hit the same
+handful of "why on earth". Here they are, answered.
+
+### Why does it patch so much of GNOME Shell?
+
+Because the thing it does has no public API anywhere. Mutter's data model is
+`window → workspace`, with the monitor absent from that relationship; the shell
+draws secondary monitors through a class chosen by a setting; and the gesture
+machinery decides which monitor a swipe belongs to in a place extensions cannot
+reach. Every seam below exists because there is no supported way to do the same
+thing.
+
+Eight of them, all reachable from two files:
+
+| Seam | Why |
+| --- | --- |
+| `Workspace._isOverviewWindow` | Splits one page of "every window on this monitor" into N virtual ones |
+| `Workspace.handleDragOver` / `acceptDrop` | The originals compare monitors, which is true of every page, so every drop was refused |
+| `SecondaryMonitorDisplay._updateWorkspacesView` | Chooses the scrolling view instead of the single-workspace one |
+| `WorkspacesDisplay._onScrollEvent` | Wheel scrolling is declined for non-primary monitors |
+| `WindowSwitcherPopup._getWindowList` | Keeps parked windows out of the window switcher |
+| Two `SwipeTracker` replacements | See below |
+
+Each override degrades rather than throws: a missing method costs a feature and
+logs a warning, it does not take the session down. All of them are undone in
+`disable()`.
+
+### Why replace the swipe tracker instead of overriding its handlers?
+
+Because overriding them does nothing, silently. The shell connects like this:
+
+```js
+swipeTracker.connect('begin', this._switchWorkspaceBegin.bind(this));
+```
+
+`.bind()` resolves the method and captures that function object at construction
+time — shell startup, long before any extension is enabled. Replacing the
+method afterwards, on the prototype or the instance, leaves the already-bound
+handler pointing at the original. The override installs, reports success, and is
+never called.
+
+Adding a second tracker alongside does not work either. `TouchpadSwipeGesture`
+enters its handling state on swipe *orientation* alone, knows nothing about
+monitors, and returns `Clutter.EVENT_STOP` even when its owner declined the
+gesture. Emission of `event` stops at the first handler returning true, and the
+shell connects at startup while an extension connects at `enable()`.
+
+So the shell's tracker is disabled — a disabled tracker's gestures return
+`EVENT_PROPAGATE`, which is what frees the events — and a replacement takes its
+place on `_swipeTracker`, where the shell's own `_updateSwipeTracker` and
+`_updateTrackerOrientation` keep managing it. Gestures that are not ours are
+handed to the original methods, which are left unpatched precisely so they can
+be called.
+
+### Why do the thumbnails use `Shell.WindowPreviewLayout` and not `Clutter.Clone`?
+
+Because a clone of a minimized window paints nothing, and on an inactive virtual
+workspace every window is minimized.
+
+GNOME's own thumbnails do not have to care — they filter minimized windows out
+on purpose:
+
+```js
+// WorkspaceThumbnail._isOverviewWindow
+return !win.get_meta_window().skip_taskbar &&
+       win.get_meta_window().showing_on_its_workspace();
+```
+
+`showing_on_its_workspace()` is false when minimized. Copying that faithfully
+would have rendered a row of identical empty rectangles. `WindowPreview` avoids
+it by building on `Shell.WindowPreviewLayout`, a C layout manager that paints
+the window's texture rather than cloning a possibly unmapped actor; the strip
+uses the same thing.
+
+### Why minimize windows instead of hiding their actors?
+
+Both were built and compared under real use:
+
+| | `actor-hide` | `minimize` ✅ chosen |
+| --- | --- | --- |
+| Visual | Instant, no animation | Minimize animation |
+| Window state | Untouched | Mutter knows it is minimized |
+| Focus | Must be handled manually | Handled by the WM |
+| Survives a native workspace switch | **No — gets overwritten** | **Yes** |
+| Risk | Inconsistent state on a crash | Lower |
+
+Hiding the actor is instant and animation-free, and it loses a race. A native
+workspace switch walks the window actors and shows those belonging to the
+incoming workspace. With `workspaces-only-on-primary` on, secondary-monitor
+windows are sticky — they belong to *every* workspace — so the shell showed all
+of them and every virtual workspace landed on screen at once.
+
+That could be papered over by re-hiding a frame later, which is a race against
+the shell rather than a fix. Minimized state is real window state that Mutter
+does not recompute, so a switch leaves it alone. Focus handover comes free,
+because the window manager already knows a minimized window cannot hold focus.
+
+The visible cost is the minimize animation and a marker in the dash. Both were
+judged acceptable; the race was not.
+
+### It says "no clones", then it clones. Which is it?
+
+Both, and the distinction is lifetime.
+
+The core model needs no clones at all: windows stay where they are and the
+extension decides which are shown. That is what keeps this from becoming a
+tiling window manager, which is the trap the alternative approach falls into.
+
+The slide animation is the exception. Showing two workspaces side by side means
+cloning their windows — there is no other way, because window actors cannot be
+moved outside their monitor. Those clones live for the ~250ms of the switch and
+are destroyed with the cover. Turning off **Slide animation** in preferences
+removes them entirely and everything else keeps working.
+
+### Why hide the shell's panel indicator instead of removing it?
+
+Because it could not be put back. `WorkspaceIndicators` is a module-private
+`const` in `panel.js` — not exported, not reachable, not constructible from an
+extension. A destroyed one is gone for the rest of the session, so the panel
+would be left permanently altered by an extension the user disabled.
+
+Hiding it and inserting ours at index 0 means `disable()` destroys ours, the
+original becomes the first child again, and `show()` restores the panel exactly
+as it was found.
+
+### Why does it set a property on `Meta.Window` objects?
+
+To tell "the extension parked this window" from "the user minimized it". Without
+that distinction, unloading would un-minimize windows the user had minimized
+themselves.
+
+The key is a namespaced symbol, `Symbol.for('workspace-islands.hidden')`, so it
+cannot collide with a plain property or with another extension's. It is removed
+when the window is restored, and `disable()` restores every window it set it on.
+
+### Why is `version` missing from `metadata.json`?
+
+Because the [guide](https://gjs.guide/extensions/overview/anatomy.html) says not
+to set it:
+
+> This field **SHOULD NOT** be set by extension developers. The GNOME Extensions
+> website will override this field and GNOME Shell may automatically upgrade or
+> downgrade an extension if the `version` field is set.
+
+The user-visible string lives in `version-name`, which is what the Extensions app
+displays. CI enforces both — the absence of one, the documented pattern of the
+other — and refuses to publish a release whose tag disagrees with it.
+
+### Is everything cleaned up when it unloads?
+
+Yes, with one documented exception that cannot be reached from outside.
+
+Every widget, signal and main loop source created is undone in `disable()`,
+including the overview views — clearing the injections restores
+`_updateWorkspacesView`, and asking each display to rebuild destroys what the
+extension built. The swipe trackers use `SwipeTracker.destroy()`, the shell's own
+teardown.
+
+The exception: `ScrollGesture` is connected upstream with a plain `connect` whose
+handler id is discarded, so nothing can disconnect it afterwards. Disabling the
+tracker before destroying it is what makes that leftover inert — every gesture
+returns `EVENT_PROPAGATE` when the tracker is disabled. It is written down in both
+modules rather than left as a silent gap.
+
+### What happens when a GNOME update moves one of these seams?
+
+Something stops working, and the rest keeps going. Every override checks that its
+target exists before installing, logs a warning naming what it could not find,
+and returns. A missing method costs a feature — the overview falls back to the
+shell's own view, the gesture goes away — and never takes the session with it.
+
+Where to look is not a mystery either: all of the seams live in `src/overview.js`
+and `src/slide.js`, each with a comment saying why that seam and not another.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ gsettings set org.gnome.mutter workspaces-only-on-primary true
 
 ## Install
 
-Not on [extensions.gnome.org](https://extensions.gnome.org) yet. For now, build it yourself:
+Not on [extensions.gnome.org](https://extensions.gnome.org) yet — that route needs review time. Until then, grab the bundle from [Releases](../../releases/latest):
+
+```bash
+gnome-extensions install --force workspace-islands@danielbernalo.github.io.shell-extension.zip
+gnome-extensions enable workspace-islands@danielbernalo.github.io
+```
+
+<details>
+<summary>Or build it from source</summary>
 
 ```bash
 git clone https://github.com/danielbernalo/gnome-workspace-islands
@@ -50,6 +58,10 @@ make pack
 gnome-extensions install --force workspace-islands@danielbernalo.github.io.shell-extension.zip
 gnome-extensions enable workspace-islands@danielbernalo.github.io
 ```
+
+Needs `python3` and `glib-compile-schemas`, both of which you already have on a GNOME system. The build is deterministic — the same commit always produces the same archive, so you can check yours against the released one.
+
+</details>
 
 Then **log out and back in**. Wayland cannot reload the shell in place, so a new extension is not picked up until the session restarts.
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -5,7 +5,10 @@
       "source": "tazztone/skills-server",
       "sourceType": "github",
       "skillPath": "skills/gnome-extension-dev/SKILL.md",
-      "computedHash": "f3b4d950a978decf27e9b29190ddde6836fdf8a21242928bce8a42f3b5fd00db"
+      "computedHash": "26405d376c1783c028f39f085ed478ee0a2707256139578da3054b0e4a10703b",
+      "ref": "d4f8f84443e84180499bc9c7a2ca84cb68898491",
+      "refDate": "2026-06-26T15:00:40Z",
+      "patched": "references/*.md links rewritten from absolute file:/// paths"
     }
   }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -12,7 +12,7 @@
 import Gio from 'gi://Gio';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
-import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import { Registry } from './monitorState.js';
 import { Keybindings } from './keybindings.js';
@@ -154,16 +154,16 @@ export default class WorkspaceIslands extends Extension {
         if (!this._mutterSettings.get_boolean(ONLY_ON_PRIMARY)) {
             Main.notifyError(
                 'Workspace Islands',
-                `Requires ${MUTTER_SCHEMA}.${ONLY_ON_PRIMARY} = true. ` +
-                'Secondary-monitor windows are not sticky without it.'
+                _('Requires %s = true. Secondary-monitor windows are not ' +
+                'sticky without it.').format(`${MUTTER_SCHEMA}.${ONLY_ON_PRIMARY}`)
             );
         }
 
         if (this._isPaperwmEnabled()) {
             Main.notifyError(
                 'Workspace Islands',
-                'PaperWM is enabled. Both extensions fight over ' +
-                `${ONLY_ON_PRIMARY} with opposite values — disable one.`
+                _('PaperWM is enabled. Both extensions fight over %s with ' +
+                'opposite values — disable one.').format(ONLY_ON_PRIMARY)
             );
         }
     }
@@ -229,8 +229,8 @@ export default class WorkspaceIslands extends Extension {
 
             Main.notifyError(
                 'Workspace Islands',
-                `${ONLY_ON_PRIMARY} was turned off. Windows on secondary ` +
-                'monitors are no longer sticky — virtual workspaces will leak.'
+                _('%s was turned off. Windows on secondary monitors are no ' +
+                'longer sticky — virtual workspaces will leak.').format(ONLY_ON_PRIMARY)
             );
         });
 

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -2,9 +2,11 @@
   "uuid": "workspace-islands@danielbernalo.github.io",
   "name": "Workspace Islands",
   "description": "Independent per-monitor workspaces for GNOME Shell — rotate workspaces on one monitor without touching the others. No tiling.",
-  "shell-version": ["50"],
+  "shell-version": [
+    "50"
+  ],
+  "version-name": "0.1.0",
   "settings-schema": "org.gnome.shell.extensions.workspace-islands",
   "gettext-domain": "workspace-islands",
-  "url": "https://github.com/danielbernalo/gnome-workspace-islands",
-  "version": 1
+  "url": "https://github.com/danielbernalo/gnome-workspace-islands"
 }

--- a/src/overview.js
+++ b/src/overview.js
@@ -80,7 +80,7 @@ import {
 import { isHiddenByUs } from './visibility.js';
 import { VirtualWorkspacesView, tagFor } from './workspacesView.js';
 
-/** Named so the replacement action can be lifted off the group on unload. */
+/** Identifies the replacement action on the group; SwipeTracker uses it too. */
 const TRACKER_NAME = 'workspace-islands overview swipe tracker';
 
 let injector = null;
@@ -113,11 +113,40 @@ export function patch({ getState, onActivate, onDrop, log }) {
 }
 
 export function unpatch() {
+    // Captured before restoreGesture() clears it.
+    const display = gestureDisplay ?? workspacesDisplay();
+
     restoreGesture();
 
     injector?.clear();
     injector = null;
     gestureView = null;
+
+    rebuildSecondaryViews(display);
+}
+
+/**
+ * Hand every secondary monitor back to the shell's own view.
+ *
+ * Clearing the injections restores `_updateWorkspacesView`, so asking each
+ * display to rebuild destroys what this module built and puts an
+ * `ExtraWorkspaceView` back in its place.
+ *
+ * Not housekeeping. A view left behind holds N Workspace pages, a background
+ * manager per thumbnail and possibly a pending idle — objects an extension
+ * created, outliving the extension, which is the one thing the review
+ * guidelines are unambiguous about.
+ */
+function rebuildSecondaryViews(display) {
+    for (const monitorDisplay of display?._workspacesViews ?? []) {
+        if (monitorDisplay?._workspacesView instanceof VirtualWorkspacesView)
+            monitorDisplay._updateWorkspacesView();
+    }
+}
+
+/** Two private hops; `controls` is a public getter, the display beyond is not. */
+function workspacesDisplay() {
+    return Main.overview?._overview?.controls?._workspacesDisplay ?? null;
 }
 
 function patchWindowFilter() {
@@ -264,7 +293,7 @@ function patchSecondaryView(getState, onActivate, onDrop) {
 function takeOverGesture(getState, log) {
     // Two private hops. `controls` is a public getter — the shell reaches
     // through it the same way in overview.js — but the display beyond it is not.
-    const display = Main.overview?._overview?.controls?._workspacesDisplay;
+    const display = workspacesDisplay();
 
     if (!display?._swipeTracker) {
         console.warn('workspace-islands: overview swipe tracker not found — ' +
@@ -355,8 +384,9 @@ function restoreGesture() {
     gestureDisplay._swipeTracker = shellTracker;
     shellTracker.enabled = true;
 
+    // See slide.js for why disabling comes before destroying.
     ourTracker.enabled = false;
-    Main.layoutManager.overviewGroup.remove_action_by_name(TRACKER_NAME);
+    ourTracker.destroy();
 
     gestureDisplay = null;
     shellTracker = null;

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -16,7 +16,7 @@ import GObject from 'gi://GObject';
 import Gtk from 'gi://Gtk?version=4.0';
 import Gdk from 'gi://Gdk?version=4.0';
 
-import { ExtensionPreferences } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
 const MUTTER_SCHEMA = 'org.gnome.mutter';
 const ONLY_ON_PRIMARY = 'workspaces-only-on-primary';
@@ -46,18 +46,18 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
 
     _generalPage(settings) {
         const page = new Adw.PreferencesPage({
-            title: 'General',
+            title: _('General'),
             icon_name: 'preferences-system-symbolic',
         });
 
         const group = new Adw.PreferencesGroup({
-            title: 'Virtual workspaces',
-            description: 'Applies to every monitor other than the primary one. ' +
-                'The primary monitor keeps using GNOME’s own workspaces.',
+            title: _('Virtual workspaces'),
+            description: _('Applies to every monitor other than the primary ' +
+                'one. The primary monitor keeps using GNOME’s own workspaces.'),
         });
 
         const count = new Adw.SpinRow({
-            title: 'Workspaces per monitor',
+            title: _('Workspaces per monitor'),
             adjustment: new Gtk.Adjustment({
                 lower: 2,
                 upper: 8,
@@ -73,10 +73,10 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
         page.add(this._feelGroup(settings));
         page.add(this._diagnosticsGroup());
 
-        const debugGroup = new Adw.PreferencesGroup({ title: 'Troubleshooting' });
+        const debugGroup = new Adw.PreferencesGroup({ title: _('Troubleshooting') });
         const debug = new Adw.SwitchRow({
-            title: 'Debug logging',
-            subtitle: 'Log workspace switches to the journal',
+            title: _('Debug logging'),
+            subtitle: _('Log workspace switches to the journal'),
         });
         settings.bind('debug-logging', debug, 'active',
             Gio.SettingsBindFlags.DEFAULT);
@@ -96,20 +96,20 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
      */
     _feelGroup(settings) {
         const group = new Adw.PreferencesGroup({
-            title: 'Switching',
-            description: 'Matches how GNOME switches its own workspaces.',
+            title: _('Switching'),
+            description: _('Matches how GNOME switches its own workspaces.'),
         });
 
         const rows = [
-            ['touchpad-gesture', 'Touchpad gesture',
-                'Three-finger swipe over a secondary monitor. GNOME’s own ' +
-                'gesture ignores those, so nothing is taken from the primary.'],
-            ['switch-animation', 'Slide animation',
-                'Slide between workspaces instead of showing the minimize ' +
-                'animation. Clones the windows involved while it runs.'],
-            ['switcher-popup', 'On-screen indicator',
-                'The workspace dots GNOME shows on a switch, on the monitor ' +
-                'that changed.'],
+            ['touchpad-gesture', _('Touchpad gesture'),
+                _('Three-finger swipe over a secondary monitor. GNOME’s own ' +
+                'gesture ignores those, so nothing is taken from the primary.')],
+            ['switch-animation', _('Slide animation'),
+                _('Slide between workspaces instead of showing the minimize ' +
+                'animation. Clones the windows involved while it runs.')],
+            ['switcher-popup', _('On-screen indicator'),
+                _('The workspace dots GNOME shows on a switch, on the monitor ' +
+                'that changed.')],
         ];
 
         for (const [key, title, subtitle] of rows) {
@@ -130,9 +130,9 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
      */
     _diagnosticsGroup() {
         const group = new Adw.PreferencesGroup({
-            title: 'Diagnostics',
-            description: 'Windows on secondary monitors must be sticky for ' +
-                'virtual workspaces to work.',
+            title: _('Diagnostics'),
+            description: _('Windows on secondary monitors must be sticky for ' +
+                'virtual workspaces to work.'),
         });
 
         let mutter;
@@ -140,8 +140,8 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
             mutter = new Gio.Settings({ schema_id: MUTTER_SCHEMA });
         } catch {
             const row = new Adw.ActionRow({
-                title: 'Could not read mutter settings',
-                subtitle: `Schema ${MUTTER_SCHEMA} is unavailable`,
+                title: _('Could not read mutter settings'),
+                subtitle: _('Schema %s is unavailable').format(MUTTER_SCHEMA),
             });
             group.add(row);
             return group;
@@ -150,7 +150,7 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
         const row = new Adw.ActionRow({ title: `${MUTTER_SCHEMA}.${ONLY_ON_PRIMARY}` });
 
         const fix = new Gtk.Button({
-            label: 'Turn on',
+            label: _('Turn on'),
             valign: Gtk.Align.CENTER,
         });
         fix.add_css_class('suggested-action');
@@ -162,8 +162,8 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
         const refresh = () => {
             const ok = mutter.get_boolean(ONLY_ON_PRIMARY);
             row.subtitle = ok
-                ? 'Enabled — virtual workspaces can work'
-                : 'Disabled — virtual workspaces will not work';
+                ? _('Enabled — virtual workspaces can work')
+                : _('Disabled — virtual workspaces will not work');
             fix.visible = !ok;
         };
 
@@ -175,15 +175,15 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
 
     _shortcutsPage(settings, window) {
         const page = new Adw.PreferencesPage({
-            title: 'Shortcuts',
+            title: _('Shortcuts'),
             icon_name: 'preferences-desktop-keyboard-symbolic',
         });
 
         const group = new Adw.PreferencesGroup({
-            title: 'Keyboard shortcuts',
-            description: 'Shortcuts act on the monitor holding the focused ' +
+            title: _('Keyboard shortcuts'),
+            description: _('Shortcuts act on the monitor holding the focused ' +
                 'window. On the primary monitor they do nothing, since GNOME’s ' +
-                'own workspace shortcuts already cover it.',
+                'own workspace shortcuts already cover it.'),
         });
 
         for (const [key, title] of SHORTCUTS)
@@ -212,7 +212,7 @@ class ShortcutRow extends Adw.ActionRow {
 
         this._label = new Gtk.ShortcutLabel({
             valign: Gtk.Align.CENTER,
-            disabled_text: 'Disabled',
+            disabled_text: _('Disabled'),
         });
         this.add_suffix(this._label);
 
@@ -245,8 +245,8 @@ class ShortcutRow extends Adw.ActionRow {
         });
 
         const status = new Adw.StatusPage({
-            title: 'Press a shortcut',
-            description: 'Esc to cancel, Backspace to clear',
+            title: _('Press a shortcut'),
+            description: _('Esc to cancel, Backspace to clear'),
             icon_name: 'preferences-desktop-keyboard-symbolic',
         });
         dialog.set_content(status);

--- a/src/slide.js
+++ b/src/slide.js
@@ -109,7 +109,7 @@ import {
 import { connectorOf } from './monitorState.js';
 import { hide, reveal } from './visibility.js';
 
-/** Named so the replacement action can be lifted off the stage on unload. */
+/** Identifies the replacement action on the stage; SwipeTracker uses it too. */
 const TRACKER_NAME = 'workspace-islands swipe tracker';
 
 /**
@@ -406,7 +406,14 @@ export class SlideController {
 
         if (this._tracker) {
             this._tracker.enabled = false;
-            global.stage.remove_action_by_name(TRACKER_NAME);
+
+        // SwipeTracker.destroy() is the shell's own teardown: it destroys the
+        // touchpad gesture and lifts the pan action off the actor. It does not
+        // reach the scroll gesture — upstream connects that one with a plain
+        // `connect` and discards the handler id, so nobody can disconnect it.
+        // Disabling first is what makes that leftover inert: every gesture
+        // returns EVENT_PROPAGATE when the tracker is disabled.
+            this._tracker.destroy();
             this._tracker = null;
         }
 


### PR DESCRIPTION
Closes #3

## Type

- [x] Maintenance or tooling — `type:chore`

## What this does

- Tagging `vX.Y.Z` now publishes an installable bundle, built without GNOME or `zip` and byte-reproducible from the commit
- Fixes two review-guideline violations found by auditing against [the official rules](https://gjs.guide/extensions/review-guidelines/review-guidelines.html)
- Makes the declared gettext domain real, and fetches the vendored agent skill by reference instead of redistributing it

## Changes

| File | Change |
| --- | --- |
| `Makefile` | `pack` rebuilt on Python's zipfile — no `zip`, no `gnome-extensions`, deterministic. New `skills` target fetches the pinned skill |
| `.github/workflows/release.yml` | Tag → verify against `version-name` → build → publish |
| `.github/workflows/ci.yml` | Bundle check now builds for real; metadata check guards the version fields |
| `src/metadata.json` | `version` dropped, `version-name: 0.1.0` added |
| `src/overview.js` | `unpatch()` destroys the views it created; tracker torn down with `SwipeTracker.destroy()` |
| `src/slide.js` | Same tracker teardown |
| `src/prefs.js`, `src/extension.js` | User-facing strings through `_()` |
| `skills-lock.json` | Pinned to a commit; records the local patch |
| `README.md`, `CONTRIBUTING.md` | Install from Releases; how to cut one |

## Review guideline findings

Two things violated *"Any objects or widgets created by an extension MUST be destroyed in `disable()`"*:

**The overview views were left behind.** `unpatch()` restored the patched methods and stopped there, so each secondary monitor kept a `VirtualWorkspacesView` — N `Workspace` pages, a background manager per thumbnail, a possible pending idle — alive after the extension unloaded.

**The swipe trackers were torn down by hand**, which missed the touchpad gesture and left a signal connection on a shell actor. `SwipeTracker` has a public `destroy()`; it is used now.

One gap remains and is documented in both modules rather than hidden: `ScrollGesture` is connected upstream with a plain `connect` whose handler id is discarded, so it cannot be disconnected from outside. Disabling the tracker first makes the leftover inert.

## How it was verified

- [x] `make doctor` passes
- [x] `make pack` twice produces identical bytes (`8f2fcf7a…`)
- [x] Bundle contains 12 modules, `LICENSE`, no `gschemas.compiled`
- [x] `.agents/` and `.claude/` deleted entirely and rebuilt by `make skills`: 6 files, hash verified, 7 links rewritten, idempotent
- [x] Installed from the bundle and confirmed self-contained — no references to the checkout
- [x] Audited against the review guidelines: no forbidden imports either direction, no deprecated modules, no `run_dispose`, nothing created during initialization, one unconditional log line
- [ ] Disable/enable cycle observed in a live session — needs the next re-login

## Shell internals

No new seams. Two existing ones change how they are undone: the swipe trackers now use `SwipeTracker.destroy()`, and the overview views are destroyed by asking each display to rebuild once the injections are cleared.

## Checklist

- [x] Linked an issue above
- [x] Exactly one `type:*` label
- [x] Conventional commit messages
- [x] README updated