### PR TITLE
fix(ci): make the release workflow parseable, and keep it that way

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -1,0 +1,26 @@
+## Install
+
+Download the `.zip` below, then:
+
+```bash
+gnome-extensions install --force workspace-islands@danielbernalo.github.io.shell-extension.zip
+gnome-extensions enable workspace-islands@danielbernalo.github.io
+```
+
+Then **log out and back in** — Wayland cannot reload the shell in place.
+
+Check it came up:
+
+```bash
+gnome-extensions info workspace-islands@danielbernalo.github.io   # State: ACTIVE
+```
+
+Requires GNOME Shell 50 on Wayland, at least two monitors, and
+`workspaces-only-on-primary` set to `true`. See the
+[README](https://github.com/danielbernalo/gnome-workspace-islands#before-you-install)
+for the full list.
+
+The build is deterministic: `make pack` at this tag reproduces the archive
+below byte for byte.
+
+---

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,20 @@ jobs:
           done
           exit $fail
 
+      # The release workflow is never exercised by CI until a tag exists, so a
+      # YAML error in it stays invisible until the moment it matters. One did.
+      - name: Workflows parse
+        run: |
+          python3 -c "
+          import pathlib, sys, yaml
+          for path in sorted(pathlib.Path('.github/workflows').glob('*.yml')):
+              try:
+                  yaml.safe_load(path.read_text())
+              except yaml.YAMLError as error:
+                  sys.exit(f'{path}: {error}')
+              print(f'ok: {path}')
+          "
+
       - name: Schema compiles
         run: glib-compile-schemas --strict --dry-run src/schemas
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,11 @@ jobs:
     name: Build and publish
     runs-on: ubuntu-latest
     steps:
+      # Tags, not just the commit: the previous one is needed to scope the
+      # generated changelog, and a shallow checkout has none.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install GLib tools
         run: sudo apt-get update && sudo apt-get install -y libglib2.0-bin
@@ -42,32 +46,20 @@ jobs:
         run: |
           uuid=$(python3 -c "import json;print(json.load(open('src/metadata.json'))['uuid'])")
 
+          # --notes-start-tag only when there is a previous tag to start from.
+          # On the first release there is none, and passing an empty value is
+          # not the same as omitting the flag.
+          previous=$(git describe --tags --abbrev=0 "$GITHUB_REF_NAME^" 2>/dev/null || true)
+          scope=()
+          [ -n "$previous" ] && scope=(--notes-start-tag "$previous")
+
+          # The notes file is prepended to the generated changelog, not
+          # replaced by it. It lives outside this workflow because a heredoc
+          # holding markdown inside a YAML block scalar is one stray column
+          # away from making the whole file unparseable.
           gh release create "$GITHUB_REF_NAME" \
             "$uuid.shell-extension.zip" \
             --title "$GITHUB_REF_NAME" \
             --generate-notes \
-            --notes-start-tag "$(git describe --tags --abbrev=0 "$GITHUB_REF_NAME^" 2>/dev/null || echo '')" \
-            --notes "$(cat <<'NOTES'
-## Install
-
-Download the `.zip` below, then:
-
-```bash
-gnome-extensions install --force workspace-islands@danielbernalo.github.io.shell-extension.zip
-gnome-extensions enable workspace-islands@danielbernalo.github.io
-```
-
-Then **log out and back in** — Wayland cannot reload the shell in place.
-
-Check it came up:
-
-```bash
-gnome-extensions info workspace-islands@danielbernalo.github.io   # State: ACTIVE
-```
-
-Requires GNOME Shell 50 on Wayland, at least two monitors, and
-`workspaces-only-on-primary` set to `true`. See the README for the full list.
-
----
-NOTES
-)"
+            "${scope[@]}" \
+            --notes-file .github/release-notes.md


### PR DESCRIPTION
Closes #3

## Type

- [x] Bug fix — `type:bug`

## What this does

- The release workflow was **not valid YAML**. The first tag would have failed before running a step
- CI now parses every workflow, not just the one it runs
- Fixes two more things that would have broken the *first* release specifically

## Changes

| File | Change |
| --- | --- |
| `.github/workflows/release.yml` | Notes moved out of the heredoc; `fetch-depth: 0` for tags; `--notes-start-tag` only when a previous tag exists |
| `.github/release-notes.md` | The install instructions, where they are not fighting two levels of quoting |
| `.github/workflows/ci.yml` | New check: every workflow in the directory parses |

## The bug

Release notes were a heredoc of markdown inside a `run: |` block, and the markdown started at column 1. That ends the YAML block scalar, leaving the rest of the file as top-level content:

```
yaml.scanner.ScannerError: found character '`' that cannot start any token
  in .github/workflows/release.yml, line 67, column 1
```

Invisible because CI only ever parsed the workflow it runs. It parses all of them now.

Two more, both specific to the first release: `actions/checkout` clones shallow with no tags, so `git describe` could never find a previous one; and `--notes-start-tag` was passed unconditionally, while on a first release there is nothing to point it at and an empty value is not the same as omitting the flag.

## How it was verified

- [x] Both workflows parse with `yaml.safe_load`
- [x] The new CI check fails on the old file and passes on the new one
- [ ] Observed on a real tag — that is `v0.1.0`, immediately after this merges

## Shell internals

None touched.

## Checklist

- [x] Linked an issue above
- [x] Exactly one `type:*` label
- [x] Conventional commit messages
- [x] README updated if behaviour changed — no behaviour changed