### PR TITLE
docs: fix the install order, which could not work as written

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -4,10 +4,17 @@ Download the `.zip` below, then:
 
 ```bash
 gnome-extensions install --force workspace-islands@danielbernalo.github.io.shell-extension.zip
-gnome-extensions enable workspace-islands@danielbernalo.github.io
 ```
 
-Then **log out and back in** — Wayland cannot reload the shell in place.
+Now **log out and back in** — Wayland cannot reload the shell in place, and until
+the session restarts the shell does not know the extension exists.
+
+That is why enabling comes *after* the restart. Run it earlier and you get
+`Extension … does not exist`, because you are asking a shell that has not looked yet:
+
+```bash
+gnome-extensions enable workspace-islands@danielbernalo.github.io
+```
 
 Check it came up:
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Not on [extensions.gnome.org](https://extensions.gnome.org) yet — that route n
 
 ```bash
 gnome-extensions install --force workspace-islands@danielbernalo.github.io.shell-extension.zip
-gnome-extensions enable workspace-islands@danielbernalo.github.io
 ```
 
 <details>
@@ -56,16 +55,23 @@ git clone https://github.com/danielbernalo/gnome-workspace-islands
 cd gnome-workspace-islands
 make pack
 gnome-extensions install --force workspace-islands@danielbernalo.github.io.shell-extension.zip
-gnome-extensions enable workspace-islands@danielbernalo.github.io
 ```
 
 Needs `python3` and `glib-compile-schemas`, both of which you already have on a GNOME system. The build is deterministic — the same commit always produces the same archive, so you can check yours against the released one.
 
 </details>
 
-Then **log out and back in**. Wayland cannot reload the shell in place, so a new extension is not picked up until the session restarts.
+Now **log out and back in**. Wayland cannot reload the shell in place, and until the session restarts the shell does not know the extension exists.
 
-Verify it loaded:
+That last part is why enabling comes *after* the restart and not before — run it any earlier and you get `Extension … does not exist`, because you are asking a shell that has not looked yet:
+
+```bash
+gnome-extensions enable workspace-islands@danielbernalo.github.io
+```
+
+The Extensions app does the same thing with a switch, if you would rather.
+
+Verify it came up:
 
 ```bash
 gnome-extensions info workspace-islands@danielbernalo.github.io   # State: ACTIVE
@@ -164,6 +170,8 @@ Windows have **no stable identity across sessions** — a window is a live objec
 - **Where each application belongs.** New windows of an app land where you last put that app. A deliberate heuristic: two windows of the same app go to the same place, which is usually right and always correctable by moving the window.
 
 ## Troubleshooting
+
+**`gnome-extensions enable` says the extension does not exist.** You have not logged out yet. That command asks the running shell, and on Wayland the shell only scans for extensions when the session starts. Install, restart the session, then enable.
 
 **A shortcut does nothing.** You are probably focused on the primary monitor, where it is a no-op by design. Turn on debug logging and the journal will say so explicitly.
 


### PR DESCRIPTION
Closes #3

## Type

- [x] Documentation only — `type:docs`

## What this does

Fixes install instructions that fail every time they are followed. This commit was on the branch but missed the #5 merge by a minute.

## The bug

Both the README and the release notes said to install and enable in one block, before restarting the session:

```
$ gnome-extensions enable workspace-islands@danielbernalo.github.io
Extension "workspace-islands@danielbernalo.github.io" does not exist
```

`enable` asks the running shell over D-Bus, and on Wayland the shell only scans for extensions when the session starts. Until you log out and back in it does not know the extension is there — the install having just succeeded makes no difference.

Reported by the first person to follow the instructions, which was the maintainer.

## Changes

| File | Change |
| --- | --- |
| `README.md` | Enable moved after the session restart, with the reason; Extensions app offered as the alternative |
| `README.md` | Troubleshooting entry for the exact error text, which reads like the install failed when it did not |
| `.github/release-notes.md` | Same correction — this is what ships with every release |

## How it was verified

- [x] Reproduced the failure on a clean install
- [x] Confirmed the extension was installed correctly the whole time: 12 modules on disk, `version-name: 0.1.0`, present in `enabled-extensions`

## Follow-up

The published `v0.1.0` notes carry the old text. The tag stays: its artifact is correct and reproduces byte for byte from the tag (`15ec332f…`). Only the prose changes, and release notes are editable in place — deleting a tag that has a published release would cost more than editing a paragraph.

## Checklist

- [x] Linked an issue above
- [x] Exactly one `type:*` label
- [x] Conventional commit messages
- [x] README updated