### PR TITLE
fix: survive suspend, lock and monitor hotplug

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The **Diagnostics** section of the same page shows the live state of `workspaces
 
 Windows have **no stable identity across sessions** — a window is a live object, and no id outlives a logout. So "put this exact window back on workspace 2" is not implementable by anyone. What is stored instead:
 
-- **Which workspace each monitor was left on**, keyed by the physical connector, so unplugging a display and plugging it back in returns it to the arrangement you left.
+- **Which workspace each monitor was left on**, keyed by the physical connector — the name the backend gives the output, like `HDMI-2` — so a display that comes back returns to its own arrangement no matter which position it comes back in.
 - **Where each application belongs.** New windows of an app land where you last put that app. A deliberate heuristic: two windows of the same app go to the same place, which is usually right and always correctable by moving the window.
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ All of them are rebindable in preferences.
 | Three-finger swipe ← / → | In the overview | Same, on the monitor under the pointer |
 | Two-finger scroll | In the overview | Switch workspace |
 | Mouse wheel | In the overview | Switch workspace |
+| `Super` + mouse wheel | On a secondary monitor | Switch workspace, one notch at a time |
 
 Over the primary monitor every gesture stays GNOME's own, untouched.
 

--- a/README.md
+++ b/README.md
@@ -162,9 +162,15 @@ journalctl -f -o cat /usr/bin/gnome-shell | grep workspace-islands
 
 The **Diagnostics** section of the same page shows the live state of `workspaces-only-on-primary` and offers a button to turn it back on. It is there because that setting is the one thing other software flips underneath you, and when it is off nothing works and the reason is invisible.
 
+## What survives a lock, an unplug or a suspend
+
+**Everything.** Each window carries a note saying which monitor and which workspace it was on, and the note lives on the window itself — so it outlasts the screen locking, the monitors going away and coming back, and the extension being turned off and on again. Come back from lunch to a redocked laptop and every window is on the workspace you left it on.
+
+This is the common case, and it is worth being precise about why it works: none of those events ends the session. The windows are the same windows the whole time, so the arrangement was never really lost — it was being thrown away and guessed back.
+
 ## What survives a logout
 
-Windows have **no stable identity across sessions** — a window is a live object, and no id outlives a logout. So "put this exact window back on workspace 2" is not implementable by anyone. What is stored instead:
+A logout is the one that genuinely cannot be complete. Windows have **no stable identity across sessions** — a window is a live object, and no id outlives a logout. So "put this exact window back on workspace 2" is not implementable by anyone. What is stored instead:
 
 - **Which workspace each monitor was left on**, keyed by the physical connector — the name the backend gives the output, like `HDMI-2` — so a display that comes back returns to its own arrangement no matter which position it comes back in.
 - **Where each application belongs.** New windows of an app land where you last put that app. A deliberate heuristic: two windows of the same app go to the same place, which is usually right and always correctable by moving the window.
@@ -378,6 +384,14 @@ themselves.
 The key is a namespaced symbol, `Symbol.for('workspace-islands.hidden')`, so it
 cannot collide with a plain property or with another extension's. It is removed
 when the window is restored, and `disable()` restores every window it set it on.
+
+There is a second one, `Symbol.for('workspace-islands.placement')`, holding which
+monitor and workspace the window was on. It is there for the opposite reason: it
+*has* to outlive the extension. The shell tears extensions down and builds them
+back up more often than you would think — every screen lock does it — and the
+window is the only thing in reach that survives that. Unlike the first, it is
+never removed, because inert data under a private key has no consequence, and it
+dies with the window either way.
 
 ### Why is `version` missing from `metadata.json`?
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -183,6 +183,16 @@ export default class WorkspaceIslands extends Extension {
      * its patches.js), say so loudly instead of misbehaving quietly.
      */
     _checkPreconditions() {
+        // enable() is no longer a once-per-session event. The shell rebases the
+        // extension order whenever it disables one, so locking the screen tears
+        // this extension down and builds it back up once for every user-only
+        // extension ahead of it in the list — and it does that while locked,
+        // now that unlock-dialog is declared. Unguarded, a misconfiguration
+        // would queue half a dozen identical notifications at every lock, all
+        // of which arrive at once when the user comes back.
+        if (Main.sessionMode.isLocked)
+            return;
+
         if (!this._mutterSettings.get_boolean(ONLY_ON_PRIMARY)) {
             Main.notifyError(
                 'Workspace Islands',

--- a/src/extension.js
+++ b/src/extension.js
@@ -15,7 +15,7 @@ import GLib from 'gi://GLib';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
-import { Registry, invalidateConnectors } from './monitorState.js';
+import { Registry, invalidateConnectors, monitorIndexOf } from './monitorState.js';
 import { placementConnector } from './placement.js';
 import { Keybindings } from './keybindings.js';
 import { Persistence } from './persistence.js';
@@ -380,15 +380,81 @@ export default class WorkspaceIslands extends Extension {
         if (!this._registry)
             return;
 
-        this._layoutChanging = false;
-
         const live = this._registry.syncMonitors();
+
+        // Before adoption: move_to_monitor() emits window-entered-monitor
+        // synchronously, and that adopts the window on the way past. Adopting
+        // first would file it against the monitor it has not been moved to yet.
+        let reclaimed = 0;
+        for (const connector of live)
+            reclaimed += this._reclaim(connector);
 
         this._adoptExistingWindows();
         for (const state of this._registry.states)
             state.reapply();
 
-        this._afterChange(`monitors settled — ${live.size} secondary`);
+        // Last, not first. Everything above travels through
+        // window-entered-monitor, which reads this flag to tell a relocation
+        // from a drag — lowering it earlier makes our own reclaim look like the
+        // user dragging every window onto the active workspace.
+        this._layoutChanging = false;
+
+        this._afterChange(
+            `monitors settled — ${live.size} secondary` +
+            (reclaimed ? `, ${reclaimed} window(s) reclaimed` : ''));
+    }
+
+    /**
+     * Bring back the windows a returning monitor lost.
+     *
+     * Mutter remembers the output a window came from and usually puts it back
+     * itself, so on real hardware this finds nothing to do. Usually is not
+     * always: virtual displays and some docks come back with a different output
+     * id, and then the monitor returns to empty virtual workspaces while its
+     * windows sit on the laptop screen. That is the reported bug wearing a
+     * different hat.
+     *
+     * Two conditions, both narrow on purpose:
+     *
+     *   the window is one *this monitor* lost when it went away, not merely one
+     *   carrying an old note. A window moved to the primary last week still has
+     *   a note naming this connector; it was never detached, and where it lives
+     *   is the user's decision, not ours.
+     *
+     *   the connector just came back. Edge-triggered, so a resolution change or
+     *   a third display appearing does not drag anything anywhere.
+     *
+     * A window moved to another *secondary* monitor excludes itself with no
+     * special case: that monitor's track() stamped its own connector on the way
+     * in, and _place() dropped it from this one's detached set.
+     *
+     * @returns {number} how many windows were moved back
+     */
+    _reclaim(connector) {
+        const state = this._registry.forConnector(connector);
+        const monitorIndex = monitorIndexOf(connector);
+        if (!state || monitorIndex < 0)
+            return 0;
+
+        let moved = 0;
+
+        for (const actor of global.get_window_actors()) {
+            const window = actor.meta_window;
+
+            if (!window || !state.wasDetached(window))
+                continue;
+
+            // Mutter got there first. Nothing to do, and moving it again would
+            // only re-derive the frame rect for no reason.
+            if (window.get_monitor() === monitorIndex)
+                continue;
+
+            this._log(`reclaiming "${window.get_title()}" onto ${connector}`);
+            window.move_to_monitor(monitorIndex);
+            moved++;
+        }
+
+        return moved;
     }
 
     _trackWindow(window, { trustPlacement = true } = {}) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -196,9 +196,10 @@ export default class WorkspaceIslands extends Extension {
         });
 
         // A window dragged onto another monitor belongs to that monitor's
-        // active virtual workspace from then on.
+        // active virtual workspace from then on — never to whatever workspace
+        // it sat on the last time it was here. A drag is a statement about now.
         this._connect(global.display, 'window-entered-monitor', (_d, _index, window) => {
-            this._trackWindow(window);
+            this._trackWindow(window, { trustPlacement: false });
         });
 
         this._connect(global.display, 'window-left-monitor', (_d, _index, window) => {
@@ -246,12 +247,12 @@ export default class WorkspaceIslands extends Extension {
         this._signals.push([object, object.connect(signal, callback)]);
     }
 
-    _trackWindow(window) {
+    _trackWindow(window, { trustPlacement = true } = {}) {
         const state = this._registry.forWindow(window);
         if (!state)
             return;
 
-        state.track(window);
+        state.track(window, -1, { trustPlacement });
         this._indicator?.sync();
 
         if (this._windowSignals.has(window))

--- a/src/extension.js
+++ b/src/extension.js
@@ -10,11 +10,13 @@
  */
 
 import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
 import { Registry } from './monitorState.js';
+import { placementConnector } from './placement.js';
 import { Keybindings } from './keybindings.js';
 import { Persistence } from './persistence.js';
 import { Indicator } from './indicator.js';
@@ -27,6 +29,24 @@ import * as OverviewFilter from './overview.js';
 const MUTTER_SCHEMA = 'org.gnome.mutter';
 const ONLY_ON_PRIMARY = 'workspaces-only-on-primary';
 const PAPERWM_UUID = 'paperwm@paperwm.github.com';
+
+/**
+ * How long to wait for the monitor layout to stop moving.
+ *
+ * `monitors-changed` is not one event. A resume or a DP-MST dock emits it two
+ * or three times within a few tens of milliseconds, and at least one of those
+ * reports a layout that never really existed — zero monitors, or only the
+ * built-in panel. Acting on the first fire re-adopts every window against a
+ * layout that is about to be replaced.
+ *
+ * The timer is rescheduled on every fire, so this is the quiet period after the
+ * last change rather than a fixed cost. An idle would not do: the fires arrive
+ * across separate main loop iterations, so an idle lands in the middle of one.
+ *
+ * Only the re-adoption waits. Releasing the windows of a monitor that just went
+ * away happens immediately — see the handler.
+ */
+const SETTLE_DELAY_MS = 300;
 
 export default class WorkspaceIslands extends Extension {
     enable() {
@@ -43,6 +63,8 @@ export default class WorkspaceIslands extends Extension {
 
         this._windowSignals = new Map();
         this._signals = [];
+        this._settleId = 0;
+        this._layoutChanging = false;
         this._keys = new Keybindings(this._settings);
 
         this._checkPreconditions();
@@ -104,6 +126,16 @@ export default class WorkspaceIslands extends Extension {
     disable() {
         AltTabFilter.unpatch();
         OverviewFilter.unpatch();
+
+        // Before the registry goes: a settle firing into a half-dismantled
+        // extension has nothing left to settle against. Nothing is left
+        // half-done by dropping it — the synchronous half of the handler has
+        // already released every window the detach touched, and restoreAll()
+        // below covers the rest.
+        if (this._settleId) {
+            GLib.Source.remove(this._settleId);
+            this._settleId = 0;
+        }
 
         // Flush before tearing anything down, or the last couple of seconds of
         // changes are lost on every logout.
@@ -197,28 +229,67 @@ export default class WorkspaceIslands extends Extension {
 
         // A window dragged onto another monitor belongs to that monitor's
         // active virtual workspace from then on — never to whatever workspace
-        // it sat on the last time it was here. A drag is a statement about now.
+        // it sat on the last time it was here. A drag is a statement about now,
+        // and honouring an old note would make the window the user is holding
+        // vanish onto a workspace they are not looking at.
+        //
+        // The same signal carries Mutter putting windows back after a hotplug,
+        // which is the exact opposite: nobody stated anything, and the note is
+        // the only record of where these windows were. Hence the flag.
         this._connect(global.display, 'window-entered-monitor', (_d, _index, window) => {
-            this._trackWindow(window, { trustPlacement: false });
+            this._trackWindow(window, { trustPlacement: this._layoutSettling });
         });
 
+        // Untracked by the note, not by forWindow(). Two reasons, and both bite:
+        // forWindow() resolves from window.get_monitor(), which by the time
+        // this fires is the monitor the window has already *arrived at* — so
+        // the monitor it left keeps it forever and minimizes it on its next
+        // switch, a window on the other screen vanishing for no reason. The
+        // index the signal hands over is no better: during a hotplug this whole
+        // burst comes out of Mutter's own monitors-changed handling, before
+        // LayoutManager has refreshed the list an index would be resolved
+        // against. The note was written while the layout was still true, and it
+        // names a connector rather than a position.
         this._connect(global.display, 'window-left-monitor', (_d, _index, window) => {
-            this._registry.forWindow(window)?.untrack(window);
+            const connector = placementConnector(window);
+            if (connector)
+                this._registry.forConnector(connector)?.untrack(window);
+        });
+
+        // Mutter announces a layout change before it applies one, and it moves
+        // windows between displays before LayoutManager re-emits below. That
+        // gap is the only window in which a relocation is indistinguishable
+        // from a drag, so the flag has to be raised at the earliest possible
+        // moment rather than at the one that is convenient.
+        //
+        // A settle is scheduled here too, not only in the handler below. A
+        // configuration that is announced and then abandoned would otherwise
+        // leave the flag raised for good, and every later drag would silently
+        // start honouring old notes.
+        this._connect(global.backend.get_monitor_manager(), 'monitors-changing', () => {
+            this._layoutChanging = true;
+            this._scheduleSettle();
         });
 
         this._connect(Main.layoutManager, 'monitors-changed', () => {
+            // First, and unconditionally. A slide in flight is pinned to a
+            // monitor index and is holding windows un-minimized behind a cover;
+            // neither survives a display arriving or leaving, and it has to go
+            // while the state still holds the groups it will be settled against.
+            this._slide?.cancel();
+
             const live = this._registry.syncMonitors();
 
-            // Unplugged monitors first: their windows are already on another
-            // display and some are still minimized by us. Left alone they read
-            // as lost windows.
+            // Unplugged monitors next, and synchronously. Their windows are
+            // already on another display and some are still minimized by us —
+            // invisible on a monitor with no virtual workspaces to explain why.
+            // Nothing about that is deferrable: the whole point of waiting
+            // below is that we do not yet know what the layout is, and a window
+            // nobody can see is not something to be unsure about.
             this._registry.pruneDetached(live);
 
-            this._adoptExistingWindows();
-            for (const state of this._registry.states)
-                state.reapply();
-
-            this._afterChange(`monitors changed — ${live.size} secondary`);
+            // Everything else waits for the layout to stop moving.
+            this._scheduleSettle();
         });
 
         // The whole model collapses if this is flipped underneath us — and it
@@ -247,6 +318,60 @@ export default class WorkspaceIslands extends Extension {
         this._signals.push([object, object.connect(signal, callback)]);
     }
 
+    /**
+     * True from the first hint of a monitor change until the settle lands.
+     *
+     * The one thing that separates "Mutter is putting windows back" from "the
+     * user dragged this here", and the only reason a placement note can be
+     * trusted in one case and must be ignored in the other.
+     */
+    get _layoutSettling() {
+        return this._layoutChanging || this._settleId !== 0;
+    }
+
+    /** Restart the quiet period. See SETTLE_DELAY_MS. */
+    _scheduleSettle() {
+        if (this._settleId)
+            GLib.Source.remove(this._settleId);
+
+        this._settleId = GLib.timeout_add(
+            GLib.PRIORITY_DEFAULT, SETTLE_DELAY_MS, () => {
+                this._settleId = 0;
+                this._settleLayout();
+                return GLib.SOURCE_REMOVE;
+            });
+
+        GLib.Source.set_name_by_id(this._settleId, '[workspace-islands] monitor settle');
+    }
+
+    /**
+     * Re-adopt against the layout that turned out to be real.
+     *
+     * Every window here goes through track(), which reads its note first, so
+     * running this against a layout that is still moving costs nothing but a
+     * repeat — the answer converges on the same arrangement either way. That is
+     * what makes the delay above a coalescing optimisation rather than a race
+     * being papered over.
+     */
+    _settleLayout() {
+        // disable() removes the source before tearing the registry down, so
+        // this should be unreachable — but a GLib callback firing into a
+        // half-dismantled extension is the kind of thing that is worth one line
+        // to make impossible rather than unlikely.
+        if (!this._registry)
+            return;
+
+        this._layoutChanging = false;
+
+        const live = this._registry.syncMonitors();
+
+        this._adoptExistingWindows();
+        for (const state of this._registry.states)
+            state.reapply();
+
+        this._afterChange(`monitors settled — ${live.size} secondary`);
+    }
+
     _trackWindow(window, { trustPlacement = true } = {}) {
         const state = this._registry.forWindow(window);
         if (!state)
@@ -260,7 +385,11 @@ export default class WorkspaceIslands extends Extension {
 
         const ids = [
             window.connect('unmanaged', () => {
-                this._registry?.forWindow(window)?.untrack(window);
+                // Everywhere, not forWindow(): a window being unmanaged has no
+                // monitor worth asking about, and it belongs nowhere now. A
+                // group left holding a dead window would minimize() it on the
+                // next reapply().
+                this._registry?.untrackEverywhere(window);
                 this._disconnectWindow(window);
                 this._indicator?.sync();
             }),

--- a/src/extension.js
+++ b/src/extension.js
@@ -15,7 +15,7 @@ import GLib from 'gi://GLib';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { Extension, gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.js';
 
-import { Registry } from './monitorState.js';
+import { Registry, invalidateConnectors } from './monitorState.js';
 import { placementConnector } from './placement.js';
 import { Keybindings } from './keybindings.js';
 import { Persistence } from './persistence.js';
@@ -50,6 +50,12 @@ const SETTLE_DELAY_MS = 300;
 
 export default class WorkspaceIslands extends Extension {
     enable() {
+        // Module state outlives the extension object — GJS keeps the module
+        // loaded across a disable/enable cycle — and displays can come and go
+        // while this is off. The cache below is the one piece of that state
+        // that would be wrong rather than merely stale.
+        invalidateConnectors();
+
         this._settings = this.getSettings();
         this._mutterSettings = new Gio.Settings({ schema_id: MUTTER_SCHEMA });
 
@@ -277,11 +283,14 @@ export default class WorkspaceIslands extends Extension {
         // leave the flag raised for good, and every later drag would silently
         // start honouring old notes.
         this._connect(global.backend.get_monitor_manager(), 'monitors-changing', () => {
+            invalidateConnectors();
             this._layoutChanging = true;
             this._scheduleSettle();
         });
 
         this._connect(Main.layoutManager, 'monitors-changed', () => {
+            invalidateConnectors();
+
             // First, and unconditionally. A slide in flight is pinned to a
             // monitor index and is holding windows un-minimized behind a cover;
             // neither survives a display arriving or leaving, and it has to go

--- a/src/extension.js
+++ b/src/extension.js
@@ -25,6 +25,7 @@ import { SlideController } from './slide.js';
 import { isApplying, isHiddenByUs, forget } from './visibility.js';
 import * as AltTabFilter from './altTab.js';
 import * as OverviewFilter from './overview.js';
+import * as ScrollFilter from './scroll.js';
 
 const MUTTER_SCHEMA = 'org.gnome.mutter';
 const ONLY_ON_PRIMARY = 'workspaces-only-on-primary';
@@ -106,6 +107,21 @@ export default class WorkspaceIslands extends Extension {
         });
 
         AltTabFilter.patch();
+
+        // Super + wheel on the desktop. The overview has its own scroll seam
+        // and already worked; this is the one outside it.
+        ScrollFilter.patch({
+            getState: () => this._registry?.forPointerMonitor() ?? null,
+
+            // Through _requestSwitch, so the wheel slides exactly like the
+            // shortcuts and the gesture do. The OSD is left to announce it, as
+            // it does on the primary monitor.
+            onScroll: (state, index, forward) =>
+                this._requestSwitch(state, index, forward),
+
+            log: message => this._log(message),
+        });
+
         OverviewFilter.patch({
             getState: index => this._registry?.forMonitorIndex(index) ?? null,
 
@@ -131,6 +147,7 @@ export default class WorkspaceIslands extends Extension {
 
     disable() {
         AltTabFilter.unpatch();
+        ScrollFilter.unpatch();
         OverviewFilter.unpatch();
 
         // Before the registry goes: a settle firing into a half-dismantled

--- a/src/indicator.js
+++ b/src/indicator.js
@@ -266,8 +266,12 @@ export class Indicator {
         this._connect(this._nativeAdjustment, 'notify::upper', () => this.sync());
         this._connect(global.display, 'notify::focus-window', () => this.sync());
 
-        // The panel is rebuilt on session mode changes, which takes our child
-        // with it and brings the shell's back. Re-attaching is idempotent.
+        // A session mode change can take our child out of the panel and bring
+        // the shell's back. In GNOME 50 it usually does not — _updatePanel only
+        // hides cached indicators and reuses them, so a lock leaves our dots
+        // parented and _attach() finds nothing to do. The listener stays
+        // because re-attaching is idempotent and cheap, and because "usually
+        // not" is a promise about an implementation detail, not an API.
         this._connect(Main.sessionMode, 'updated', () => this._attach());
 
         this._attach();

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -9,7 +9,7 @@
     "user",
     "unlock-dialog"
   ],
-  "version-name": "0.1.0",
+  "version-name": "0.1.1",
   "settings-schema": "org.gnome.shell.extensions.workspace-islands",
   "gettext-domain": "workspace-islands",
   "url": "https://github.com/danielbernalo/gnome-workspace-islands"

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -5,6 +5,10 @@
   "shell-version": [
     "50"
   ],
+  "session-modes": [
+    "user",
+    "unlock-dialog"
+  ],
   "version-name": "0.1.0",
   "settings-schema": "org.gnome.shell.extensions.workspace-islands",
   "gettext-domain": "workspace-islands",

--- a/src/monitorState.js
+++ b/src/monitorState.js
@@ -456,6 +456,17 @@ export class Registry {
 }
 
 /**
+ * Index -> connector for the current layout, or null when it needs rereading.
+ *
+ * Cached because this is not a cold path: the indicator resolves the focused
+ * monitor on every frame of a swipe preview, and asking the backend to name
+ * every output sixty times a second to answer a question whose answer cannot
+ * change mid-gesture is work for nothing. {@link invalidateConnectors} is the
+ * other half — the layout is the only thing that can make this stale.
+ */
+let connectors = null;
+
+/**
  * The connector driving a monitor index — "HDMI-2", not "monitor-1".
  *
  * This module is keyed by connector precisely because indices are reshuffled on
@@ -472,6 +483,18 @@ export class Registry {
  * attached monitors gives exactly the mapping this module always assumed it had.
  */
 export function connectorOf(index) {
+    connectors ??= readConnectors();
+    return connectors[index] ?? `monitor-${index}`;
+}
+
+/** Drop the cache. Call whenever the monitor layout is about to change. */
+export function invalidateConnectors() {
+    connectors = null;
+}
+
+function readConnectors() {
+    const map = [];
+
     try {
         const manager = global.backend.get_monitor_manager();
 
@@ -480,8 +503,12 @@ export function connectorOf(index) {
                 continue;
 
             const connector = monitor.get_connector();
-            if (connector && manager.get_monitor_for_connector(connector) === index)
-                return connector;
+            if (!connector)
+                continue;
+
+            const index = manager.get_monitor_for_connector(connector);
+            if (index >= 0)
+                map[index] = connector;
         }
     } catch (e) {
         // A backend that cannot name its monitors is not a reason to stop
@@ -490,7 +517,7 @@ export function connectorOf(index) {
         console.warn(`workspace-islands: could not read monitor connectors: ${e}`);
     }
 
-    return `monitor-${index}`;
+    return map;
 }
 
 /**

--- a/src/monitorState.js
+++ b/src/monitorState.js
@@ -11,7 +11,9 @@
  * set of windows we agree to show together.
  *
  * Monitors are keyed by `connector` (e.g. "HDMI-2") rather than by index,
- * because indices are reshuffled on hotplug while connectors are stable.
+ * because indices are reshuffled on hotplug while connectors are stable. The
+ * name comes from the backend, not from the shell's `Monitor` — see
+ * {@link connectorOf}, which is where that distinction was once lost.
  */
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -262,11 +264,11 @@ export class Registry {
         const primaryIndex = Main.layoutManager.primaryIndex;
         const live = new Set();
 
-        Main.layoutManager.monitors.forEach((monitor, index) => {
+        Main.layoutManager.monitors.forEach((_monitor, index) => {
             if (index === primaryIndex)
                 return;
 
-            const connector = connectorOf(monitor, index);
+            const connector = connectorOf(index);
             live.add(connector);
 
             if (!this._states.has(connector))
@@ -299,11 +301,10 @@ export class Registry {
         if (index < 0 || index === Main.layoutManager.primaryIndex)
             return null;
 
-        const monitor = Main.layoutManager.monitors[index];
-        if (!monitor)
+        if (!Main.layoutManager.monitors[index])
             return null;
 
-        return this.forConnector(connectorOf(monitor, index));
+        return this.forConnector(connectorOf(index));
     }
 
     /** State for the monitor a window sits on, or null if it is on primary. */
@@ -312,11 +313,10 @@ export class Registry {
         if (index < 0 || index === Main.layoutManager.primaryIndex)
             return null;
 
-        const monitor = Main.layoutManager.monitors[index];
-        if (!monitor)
+        if (!Main.layoutManager.monitors[index])
             return null;
 
-        return this.forConnector(connectorOf(monitor, index));
+        return this.forConnector(connectorOf(index));
     }
 
     /**
@@ -333,11 +333,10 @@ export class Registry {
         if (index < 0 || index === Main.layoutManager.primaryIndex)
             return null;
 
-        const monitor = Main.layoutManager.monitors[index];
-        if (!monitor)
+        if (!Main.layoutManager.monitors[index])
             return null;
 
-        return this.forConnector(connectorOf(monitor, index));
+        return this.forConnector(connectorOf(index));
     }
 
     /** Human-readable resolution trace, for diagnosing "nothing happened". */
@@ -374,8 +373,53 @@ export class Registry {
     }
 }
 
-export function connectorOf(monitor, index) {
-    return monitor.connector ?? `monitor-${index}`;
+/**
+ * The connector driving a monitor index — "HDMI-2", not "monitor-1".
+ *
+ * This module is keyed by connector precisely because indices are reshuffled on
+ * hotplug. Until now that was an intention rather than a fact: the shell's
+ * `Monitor` is `(index, geometry, scale)` and carries no name, so
+ * `monitor.connector` was always undefined and every key fell through to the
+ * positional fallback. The model was keyed by index after all — unplug a
+ * display, plug it back in second instead of first, and "the LG's workspace 3"
+ * was restored onto whatever now sat at index 1.
+ *
+ * The name has to come from the backend. `get_monitor_for_connector` answers
+ * with the logical monitor index a connector currently drives, and that is the
+ * same index space `Main.layoutManager.monitors` uses, so one pass over the
+ * attached monitors gives exactly the mapping this module always assumed it had.
+ */
+export function connectorOf(index) {
+    try {
+        const manager = global.backend.get_monitor_manager();
+
+        for (const monitor of manager.get_monitors()) {
+            if (!monitor.is_active())
+                continue;
+
+            const connector = monitor.get_connector();
+            if (connector && manager.get_monitor_for_connector(connector) === index)
+                return connector;
+        }
+    } catch (e) {
+        // A backend that cannot name its monitors is not a reason to stop
+        // working. Positional keys are what this did before, and they are right
+        // for as long as nothing is unplugged.
+        console.warn(`workspace-islands: could not read monitor connectors: ${e}`);
+    }
+
+    return `monitor-${index}`;
+}
+
+/**
+ * Current index for a connector, or -1 if that display is not attached.
+ *
+ * Lives here rather than in the two modules that had identical private copies:
+ * both were scanning a monitor list that does not know its own names.
+ */
+export function monitorIndexOf(connector) {
+    return Main.layoutManager.monitors.findIndex(
+        (_monitor, index) => connectorOf(index) === connector);
 }
 
 function clamp(value, min, max) {

--- a/src/monitorState.js
+++ b/src/monitorState.js
@@ -445,6 +445,19 @@ export class Registry {
         return this.forConnector(connectorOf(index));
     }
 
+    /**
+     * State for the monitor under the pointer, or null if that's primary.
+     *
+     * The deliberate opposite of {@link forFocusedMonitor}, and for the reason
+     * stated there in reverse: a shortcut is pressed with a hand on the
+     * keyboard, so the focused window decides. A wheel is turned with a hand on
+     * the mouse, so the pointer decides. Asking the focused window where a
+     * wheel notch belongs would scroll a screen the user is not pointing at.
+     */
+    forPointerMonitor() {
+        return this.forMonitorIndex(global.display.get_current_monitor());
+    }
+
     /** Human-readable resolution trace, for diagnosing "nothing happened". */
     describeFocusTarget() {
         const focused = global.display.focus_window;

--- a/src/monitorState.js
+++ b/src/monitorState.js
@@ -81,6 +81,12 @@ export class MonitorState {
     _place(window, index) {
         this._groups[index].add(window);
         stamp(window, this.connector, index);
+
+        // Back in a group, so no longer owed a ride home. Clearing it here
+        // rather than in the reclaim itself means a window is reclaimed at most
+        // once per disconnect however it got back — under its own steam, by
+        // Mutter, or by us.
+        this._detached?.delete(window);
     }
 
     get size() {
@@ -258,10 +264,28 @@ export class MonitorState {
                 stamp(window, this.connector, index);
         }
 
+        // Which windows this monitor lost, so the ones Mutter does not bring
+        // back can be fetched when it returns. A WeakSet because it is only
+        // ever asked "was this one yours" and never walked — a window closed
+        // while the display is unplugged must not be kept alive by our
+        // bookkeeping, and would be a dead reference by the time it came back.
+        this._detached = new WeakSet(this.allWindows);
+
         this.restoreAll();
 
         for (const group of this._groups)
             group.clear();
+    }
+
+    /**
+     * True if this monitor lost this window when it was unplugged.
+     *
+     * The difference between "belongs here" and "is owed a ride home". A window
+     * the user moved to the laptop screen last week still carries a note naming
+     * this monitor; it was not detached, and dragging it back is their call.
+     */
+    wasDetached(window) {
+        return this._detached?.has(window) ?? false;
     }
 
     /** Resize the workspace count, folding anything beyond the new end. */

--- a/src/monitorState.js
+++ b/src/monitorState.js
@@ -358,6 +358,18 @@ export class Registry {
         return this._states.get(connector) ?? null;
     }
 
+    /**
+     * Drop a window from every state. For a window that is going away.
+     *
+     * Bookkeeping only — no un-hiding, because there is nothing left to show.
+     * Total on purpose: a dying window's monitor is not worth asking about, and
+     * a group left holding one would minimize() it on the next reapply().
+     */
+    untrackEverywhere(window) {
+        for (const state of this._states.values())
+            state.untrack(window);
+    }
+
     /** Create state for a connector that is not currently attached. */
     ensureConnector(connector) {
         if (!this._states.has(connector))

--- a/src/monitorState.js
+++ b/src/monitorState.js
@@ -203,14 +203,22 @@ export class MonitorState {
         return true;
     }
 
-    /** Apply the current active index to every window this monitor holds. */
+    /**
+     * Apply the current active index to every window this monitor holds.
+     *
+     * Instant, never animated. This runs at enable() and after a hotplug —
+     * always "bring the screen in line with a model that changed underneath
+     * it", never a transition the user asked to watch. Animated, an unlock
+     * would open with every window on every inactive workspace minimizing
+     * itself in sequence.
+     */
     reapply() {
         for (let i = 0; i < this.size; i++) {
             for (const window of this.windowsOn(i)) {
                 if (i === this.activeIndex)
-                    show(window);
+                    show(window, { animate: false });
                 else
-                    hide(window);
+                    hide(window, { animate: false });
             }
         }
     }
@@ -219,7 +227,7 @@ export class MonitorState {
     restoreAll() {
         for (const window of this.allWindows) {
             if (isHiddenByUs(window))
-                show(window);
+                show(window, { animate: false });
         }
     }
 
@@ -229,11 +237,29 @@ export class MonitorState {
      * Used when the monitor is unplugged: its windows have already been moved
      * to another monitor by Mutter, and any we had hidden are still minimized
      * — invisible on a monitor that has no virtual workspaces to explain why.
-     * They get shown and dropped. activeIndex and the app rules survive, so
-     * plugging the display back in restores its arrangement.
+     * They get shown and dropped.
+     *
+     * The groups really are cleared, and that is deliberate. Keeping them would
+     * mean two monitors owning the same window: the display that took the
+     * windows tracks them, and this one would still hold them and minimize them
+     * on its next switch — a window on the other screen vanishing for no
+     * visible reason. The note replaces the group; it does not supplement it.
+     *
+     * Re-stamping first is what makes the unplug survivable. Every window in a
+     * group is already stamped — _place() is the only way in — so the loop is
+     * redundant today, and it is written out anyway because this is the one
+     * place where the note stops being a second copy of the group and becomes
+     * the only surviving record of it. A future edit that finds another way
+     * into a group should fail here, not silently on the next dock.
      */
     detach() {
+        for (let index = 0; index < this.size; index++) {
+            for (const window of this.windowsOn(index))
+                stamp(window, this.connector, index);
+        }
+
         this.restoreAll();
+
         for (const group of this._groups)
             group.clear();
     }

--- a/src/monitorState.js
+++ b/src/monitorState.js
@@ -20,6 +20,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 import { hide, show, isHiddenByUs } from './visibility.js';
 import { appKeyOf } from './persistence.js';
+import { stamp, placementIndex } from './placement.js';
 
 export class MonitorState {
     constructor(connector, size) {
@@ -61,6 +62,27 @@ export class MonitorState {
         return clamp(this._appRules.get(key), 0, this.size - 1);
     }
 
+    /** Where this exact window was on this monitor, or -1 if we have no note. */
+    indexForPlacement(window) {
+        const index = placementIndex(window, this.connector);
+
+        // Clamped like indexForApp, and for a sharper reason: a note can
+        // outlive a shrink of `virtual-workspaces`, because resize() can only
+        // reach windows that are in a group at the time.
+        return index < 0 ? -1 : clamp(index, 0, this.size - 1);
+    }
+
+    /**
+     * The one way into a group: membership and note are written together.
+     *
+     * Private so that "a window in a group carries a current note" is an
+     * invariant rather than a habit. detach() depends on it — see there.
+     */
+    _place(window, index) {
+        this._groups[index].add(window);
+        stamp(window, this.connector, index);
+    }
+
     get size() {
         return this._groups.length;
     }
@@ -85,24 +107,47 @@ export class MonitorState {
     /**
      * Assign a window to a virtual workspace.
      *
-     * With no explicit index, an app rule decides; failing that, the active
-     * workspace. A window that lands somewhere other than the active workspace
-     * is hidden immediately — otherwise it appears on screen for a moment and
-     * then vanishes, which reads as a bug.
+     * Four answers, in descending order of how much they actually know:
      *
+     *   explicit index   a drop or a move. The user just said where.
+     *   placement note   this exact window was on workspace N of this exact
+     *                    monitor, and something churned in between — a lock
+     *                    screen, an unplug, a resume. Not a guess: a record.
+     *   app rule         a window we have never seen, of an app we have. A
+     *                    guess, and a good one.
+     *   active index     nothing is known. Put it where the user is looking.
+     *
+     * The note outranks the rule because they answer different questions. The
+     * rule says "windows of this app usually live on 3"; the note says "this
+     * window was on 2, four hundred milliseconds ago". A resume that consulted
+     * the rule first collapses every window of an app into one workspace, which
+     * is the entire bug this ordering exists to prevent.
+     *
+     * A window that lands somewhere other than the active workspace is hidden
+     * immediately — otherwise it appears on screen for a moment and then
+     * vanishes, which reads as a bug.
+     *
+     * @param {object} [options]
+     * @param {boolean} [options.trustPlacement] consult the note. False for a
+     *   window the user just dragged here: a drag is a statement about *now*,
+     *   and honouring an old note would make the window they are holding
+     *   vanish onto some workspace they are not looking at. Every other caller
+     *   is recovering from churn, where the note is the whole point.
      * @returns {number} the index it was assigned to, or -1 if already tracked
      */
-    track(window, index = -1) {
+    track(window, index = -1, { trustPlacement = true } = {}) {
         if (this.indexOf(window) !== -1)
             return -1;
 
         let target = index;
         if (target < 0 || target >= this.size)
+            target = trustPlacement ? this.indexForPlacement(window) : -1;
+        if (target < 0)
             target = this.indexForApp(window);
         if (target < 0)
             target = this.activeIndex;
 
-        this._groups[target].add(window);
+        this._place(window, target);
 
         if (target !== this.activeIndex)
             hide(window);
@@ -144,7 +189,7 @@ export class MonitorState {
             return false;
 
         this._groups[from].delete(window);
-        this._groups[index].add(window);
+        this._place(window, index);
 
         // Moving a window by hand is the strongest signal we get about where
         // its application belongs, so it updates the rule.
@@ -207,10 +252,9 @@ export class MonitorState {
         // Shrinking: everything past the new end collapses into the last group
         // rather than vanishing along with its windows.
         const tail = this._groups.splice(size);
-        const last = this._groups[size - 1];
         for (const group of tail) {
             for (const window of group)
-                last.add(window);
+                this._place(window, size - 1);
         }
 
         if (this.activeIndex >= size)

--- a/src/overview.js
+++ b/src/overview.js
@@ -78,6 +78,7 @@ import {
 } from 'resource:///org/gnome/shell/ui/workspacesView.js';
 
 import { isHiddenByUs } from './visibility.js';
+import { scrollDelta } from './scroll.js';
 import { VirtualWorkspacesView, tagFor } from './workspacesView.js';
 
 /** Identifies the replacement action on the group; SwipeTracker uses it too. */
@@ -474,18 +475,6 @@ function patchScroll(getState, log) {
 }
 
 /** -1, 1 or 0 for anything that is not a discrete step. */
-function scrollDelta(event) {
-    switch (event.get_scroll_direction()) {
-    case Clutter.ScrollDirection.UP:
-    case Clutter.ScrollDirection.LEFT:
-        return -1;
-    case Clutter.ScrollDirection.DOWN:
-    case Clutter.ScrollDirection.RIGHT:
-        return 1;
-    default:
-        return 0;
-    }
-}
 
 /** Same computation as WorkspacesDisplay._getMonitorIndexForEvent, in public API. */
 function monitorIndexOf(event) {

--- a/src/overview.js
+++ b/src/overview.js
@@ -71,7 +71,7 @@ import { InjectionManager } from 'resource:///org/gnome/shell/extensions/extensi
 import * as DND from 'resource:///org/gnome/shell/ui/dnd.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as SwipeTracker from 'resource:///org/gnome/shell/ui/swipeTracker.js';
-import { Workspace } from 'resource:///org/gnome/shell/ui/workspace.js';
+import { Workspace, WorkspaceBackground } from 'resource:///org/gnome/shell/ui/workspace.js';
 import {
     SecondaryMonitorDisplay,
     WorkspacesDisplay,
@@ -107,6 +107,7 @@ export function patch({ getState, onActivate, onDrop, log }) {
 
     patchWindowFilter();
     patchDropTarget();
+    patchOrphanedBackground();
     patchSecondaryView(getState, onActivate, onDrop);
     takeOverGesture(getState, log);
     patchScroll(getState, log);
@@ -235,6 +236,47 @@ function patchDropTarget() {
             // page carries that this module put there.
             virtual.onDrop?.(virtual.index, source.metaWindow, this.monitorIndex);
             return true;
+        });
+}
+
+/**
+ * Stop a background from reading the geometry of a monitor that just left.
+ *
+ * `WorkspaceBackground` keeps a monitor index and connects `workareas-changed`
+ * to recompute its rounded clip against `Main.layoutManager.monitors[index]`.
+ * Unplug that monitor and the signal arrives while the index is already past
+ * the end of the list, so the handler dereferences `undefined` and throws
+ * before anything gets round to destroying the view.
+ *
+ * This is the shell's own code and the shell's own bug — its single
+ * `ExtraWorkspaceView` per secondary monitor hits it too, once, which is quiet
+ * enough that nobody has chased it. What makes it worth patching from here is
+ * that this extension gives a secondary monitor one page per virtual
+ * workspace, so the same unplug throws once per page: four JS errors and a
+ * wall of allocation warnings on every dock, all of them pointing at shell
+ * files and none of them mentioning this extension. A future maintainer
+ * reading that journal would have no reason to suspect us and every reason to
+ * lose an evening.
+ *
+ * Returning early is the whole fix. The view is about to be rebuilt against
+ * the new layout, so there is no clip worth computing and nothing downstream
+ * of it that survives.
+ */
+function patchOrphanedBackground() {
+    const proto = WorkspaceBackground?.prototype;
+
+    if (!proto || typeof proto._updateRoundedClipBounds !== 'function') {
+        console.warn('workspace-islands: WorkspaceBackground._updateRoundedClipBounds ' +
+            'not found — unplugging a monitor will log harmless JS errors');
+        return;
+    }
+
+    injector.overrideMethod(proto, '_updateRoundedClipBounds',
+        originalMethod => function () {
+            if (!Main.layoutManager.monitors[this._monitorIndex])
+                return;
+
+            originalMethod.call(this);
         });
 }
 

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -4,9 +4,17 @@
  * A hard limit shapes this module: **windows have no stable identity across
  * sessions**. A MetaWindow is a live object; nothing about it survives a
  * logout, and no id can be trusted to mean the same window tomorrow. So
- * "restore this window to virtual workspace 2" is not implementable.
+ * "restore this window to virtual workspace 2" is not implementable *here*.
  *
- * What is implementable, and what people actually mean when they ask for it:
+ * Note the emphasis on *across sessions*. Almost nothing that loses an
+ * arrangement is a new session — a lock, a suspend, a monitor unplugged over
+ * lunch all happen inside one, where the MetaWindow objects are the same
+ * objects and the exact mapping is recoverable. That case is not this module's
+ * to solve and it is not lost; see placement.js, which puts the record on the
+ * window instead of in gsettings precisely because it must not outlive it.
+ *
+ * What is implementable here, and what people actually mean when they ask for
+ * a setup that survives a logout:
  *
  *   activeIndex   which virtual workspace each monitor was left on. Restoring
  *                 this is what makes the setup feel like it stayed put.

--- a/src/placement.js
+++ b/src/placement.js
@@ -1,0 +1,66 @@
+/**
+ * Where a window was, for as long as the window lives.
+ *
+ * persistence.js opens by stating a hard limit: windows have no stable identity
+ * *across sessions*. That is true, and it is also the wrong limit to plan
+ * around, because almost nothing that loses an arrangement is a new session. A
+ * lock screen disables the extension and re-enables it four minutes later. A
+ * suspend takes every monitor down and brings it back. A dock is unplugged over
+ * lunch. In all of those the shell process never died and the MetaWindow
+ * objects are the same objects — the mapping was recoverable the whole time,
+ * and it was being thrown away and then guessed back from WM_CLASS, which is
+ * how four workspaces of one browser come back as one.
+ *
+ * So each window carries a note: the connector it was on and the virtual
+ * workspace it was on there, written onto the MetaWindow's JS wrapper under a
+ * namespaced symbol. visibility.js already does exactly this with its HIDDEN
+ * tag, for exactly the same reason — the note has to outlive the extension
+ * object, and the window is the only thing in reach that does.
+ *
+ * `Symbol.for`, not `Symbol()`. The global registry is what makes the key the
+ * same key after a disable/enable cycle; a private symbol would be a fresh,
+ * unrelated key on every re-import and every note left by the previous life
+ * would be invisible. (workspacesView.js uses a private symbol for its page
+ * tags, and that is right there — those never outlive the view that made them.)
+ *
+ * Surviving disable/enable is not a nicety. The shell rebases the extension
+ * order when it disables one: disabling any extension also disables, and then
+ * re-enables, every extension after it. So a lock screen tears this extension
+ * down whether or not it declares `unlock-dialog`, once for every user-only
+ * extension ahead of it in the list.
+ *
+ * The connector is stored alongside the index because an index alone means
+ * nothing once a window has been moved to another display. A note is only ever
+ * read back by the monitor it names.
+ *
+ * A note is written, overwritten, and never cleared. Overwriting is what makes
+ * a move between two secondary monitors correct itself with no special case:
+ * the new monitor stamps its own connector on the way in, and the old note is
+ * simply no longer the note anybody asks for. Nothing needs cleaning up on
+ * unload either — this is inert data under a key nobody else uses, dying with
+ * the window. That is the difference from the HIDDEN tag, which *is* cleared on
+ * unload, because leaving that one behind leaves a window minimized and
+ * unreachable.
+ */
+
+const PLACEMENT = Symbol.for('workspace-islands.placement');
+
+/**
+ * @param {Meta.Window} window
+ * @param {string} connector the monitor the index belongs to
+ * @param {number} index virtual workspace on that monitor
+ */
+export function stamp(window, connector, index) {
+    window[PLACEMENT] = { connector, index };
+}
+
+/** Virtual workspace this window was on `connector`, or -1 if unrecorded. */
+export function placementIndex(window, connector) {
+    const placement = window[PLACEMENT];
+    return placement?.connector === connector ? placement.index : -1;
+}
+
+/** The monitor this window was last placed on, or null if it has no note. */
+export function placementConnector(window) {
+    return window[PLACEMENT]?.connector ?? null;
+}

--- a/src/scroll.js
+++ b/src/scroll.js
@@ -1,0 +1,180 @@
+/**
+ * Super + mouse wheel, outside the overview.
+ *
+ * On the primary monitor this is one of GNOME's oldest habits: hold Super,
+ * spin the wheel, walk through the workspaces. On a secondary monitor it did
+ * nothing visible, and the reason is worth writing down because it is not the
+ * one you would guess from the touchpad working fine.
+ *
+ * The two inputs part company early. `WindowManager` connects a single
+ * `scroll-event` handler on the stage and asks the workspace animation first
+ * whether it wants the event:
+ *
+ *     if (this._workspaceAnimation.canHandleScrollEvent(event))
+ *         return Clutter.EVENT_PROPAGATE;
+ *     ...
+ *     return this.handleWorkspaceScroll(event);
+ *
+ * `canHandleScrollEvent` forwards to the SwipeTracker, which claims *smooth*
+ * events — a touchpad. So two-finger and three-finger scrolling reach the
+ * tracker, and slide.js already replaced that tracker with one that knows
+ * about monitors. A discrete wheel click is not smooth, falls past that check,
+ * and lands in `handleWorkspaceScroll`.
+ *
+ * And `handleWorkspaceScroll` has no notion of a monitor at all. It reads
+ * `global.workspace_manager`, takes the active workspace's neighbour and
+ * switches to it — wherever the pointer happens to be. With
+ * `workspaces-only-on-primary = true` that moves the primary monitor and
+ * leaves the secondary exactly as it was, which is precisely the report: the
+ * gesture works, the wheel does not.
+ *
+ * So this is the sixth shell seam, and the easiest of them. The stage handler
+ * calls `this.handleWorkspaceScroll(event)` as a live method lookup rather
+ * than through a handler captured with `.bind()` at construction — the trap
+ * slide.js and overview.js each document having fallen into. Overriding the
+ * prototype is enough.
+ */
+
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+
+import { InjectionManager } from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import { WindowManager } from 'resource:///org/gnome/shell/ui/windowManager.js';
+
+/**
+ * The shell's own rate limit, matched rather than reinvented.
+ *
+ * A wheel notch sends events far faster than a workspace can be switched, and
+ * the shell throttles its own path to one switch per 150 ms. Both paths share
+ * the `_canScroll` flag on the same WindowManager, so a wheel dragged across
+ * the boundary between the two monitors keeps a single cadence instead of
+ * accelerating as it crosses.
+ */
+const SCROLL_TIMEOUT_MS = 150;
+
+let injector = null;
+
+/** The pending throttle, so unpatch() can drop it. See {@link releaseScroll}. */
+let throttleId = 0;
+
+/**
+ * @param {object} handlers
+ * @param {() => object|null} handlers.getState state for the monitor under the
+ *   pointer, or null when that is the primary
+ * @param {(state: object, index: number, forward: boolean) => void}
+ *   handlers.onScroll commit the switch
+ * @param {(message: string) => void} handlers.log
+ */
+export function patch({ getState, onScroll, log }) {
+    const proto = WindowManager?.prototype;
+
+    // Never assume the seam is there. A shell that renames or drops this must
+    // degrade to "the wheel only moves the primary monitor" — which is the
+    // behaviour being fixed, not a broken extension.
+    if (!proto || typeof proto.handleWorkspaceScroll !== 'function') {
+        console.warn('workspace-islands: WindowManager.handleWorkspaceScroll not ' +
+            'found — Super + wheel will not switch workspaces on secondary monitors');
+        return;
+    }
+
+    injector = new InjectionManager();
+
+    injector.overrideMethod(proto, 'handleWorkspaceScroll',
+        originalMethod => function (event) {
+            const state = getState();
+            if (!state)
+                return originalMethod.call(this, event);
+
+            if (!this._canScroll)
+                return Clutter.EVENT_PROPAGATE;
+
+            const delta = scrollDelta(event);
+            if (delta === 0)
+                return Clutter.EVENT_PROPAGATE;
+
+            // Clamped, not wrapped — unlike the keyboard shortcuts, which do
+            // wrap. This is deliberate and the asymmetry is the point: the
+            // wheel is being asked to feel exactly like the wheel on the
+            // primary monitor, and there it stops at the ends. A shortcut has
+            // no such reference to live up to.
+            const to = Math.min(Math.max(state.activeIndex + delta, 0), state.size - 1);
+
+            if (to !== state.activeIndex) {
+                log(`wheel on ${state.connector}: ` +
+                    `${state.activeIndex + 1} -> ${to + 1}`);
+                onScroll(state, to, delta > 0);
+            }
+
+            // Even when the switch was a no-op at the end of the range. The
+            // event belonged to this monitor either way, and letting it fall
+            // through would hand it to the primary — a wheel that does nothing
+            // until you reach the last workspace and then starts moving the
+            // *other* screen.
+            this._canScroll = false;
+            throttle(this);
+
+            return Clutter.EVENT_STOP;
+        });
+}
+
+export function unpatch() {
+    injector?.clear();
+    injector = null;
+
+    releaseScroll();
+}
+
+/**
+ * Hold the wheel for one beat, and be able to let go early.
+ *
+ * The shell fires this and forgets it, which is its privilege — it is not
+ * going anywhere. An extension that did the same would leave a source running
+ * into a session where it no longer exists. Harmless in itself, since all the
+ * callback does is restore a flag to the value the shell keeps it at anyway,
+ * but "harmless leak" is not a category this is worth having.
+ */
+function throttle(windowManager) {
+    releaseScroll();
+
+    throttleId = GLib.timeout_add_once(
+        GLib.PRIORITY_DEFAULT, SCROLL_TIMEOUT_MS, () => {
+            throttleId = 0;
+            windowManager._canScroll = true;
+        });
+}
+
+/** Drop a pending throttle and hand the wheel straight back to the shell. */
+function releaseScroll() {
+    if (throttleId) {
+        GLib.Source.remove(throttleId);
+        throttleId = 0;
+    }
+
+    // Unconditionally, not only when a throttle was pending: unloading in the
+    // middle of the hold would otherwise leave the shell's own wheel jammed
+    // until something else happened to set it back.
+    if (Main.wm)
+        Main.wm._canScroll = true;
+}
+
+/**
+ * One wheel notch as a step: -1 back, +1 forward, 0 for anything else.
+ *
+ * Shared with the overview, which needs the identical mapping for its own
+ * scroll seam. Smooth events return 0 here and are meant to: they belong to a
+ * swipe tracker, which drives the same value continuously, and stepping it as
+ * well would fight the gesture.
+ */
+export function scrollDelta(event) {
+    switch (event.get_scroll_direction()) {
+    case Clutter.ScrollDirection.UP:
+    case Clutter.ScrollDirection.LEFT:
+        return -1;
+    case Clutter.ScrollDirection.DOWN:
+    case Clutter.ScrollDirection.RIGHT:
+        return 1;
+    default:
+        return 0;
+    }
+}

--- a/src/slide.js
+++ b/src/slide.js
@@ -547,6 +547,31 @@ export class SlideController {
         this._teardown(session);
     }
 
+    /**
+     * Drop a slide in flight, from outside.
+     *
+     * Two callers, both cases where the slide has stopped meaning anything and
+     * nothing will tell it so:
+     *
+     *   a monitor layout change — the cover is pinned to a monitor index and
+     *   its pages hold background managers for it, and neither survives a
+     *   display arriving or leaving. Worse, once the state is detached
+     *   _settle() finds indexOf() === -1 for every revealed window and hides
+     *   the lot, tagged, with no group left to restore them from.
+     *
+     *   the screen locking — the shell's modal grab moves Main.actionMode to
+     *   LOCK_SCREEN, and SwipeTracker drops events that do not match its
+     *   allowed modes *before* it emits 'end'. The gesture never finishes, so
+     *   _session stays set, sliding is dead for the rest of the session, the
+     *   cover stays on the stage and disable_unredirect() is never balanced.
+     *
+     * Must be called while the state still holds its groups — before
+     * pruneDetached(), not after.
+     */
+    cancel() {
+        this._cancel();
+    }
+
     /** Drop the cover without committing. Leaves the screen as it was. */
     _cancel() {
         const session = this._session;

--- a/src/slide.js
+++ b/src/slide.js
@@ -106,7 +106,7 @@ import {
     WORKSPACE_SPACING,
 } from 'resource:///org/gnome/shell/ui/workspaceAnimation.js';
 
-import { connectorOf } from './monitorState.js';
+import { monitorIndexOf } from './monitorState.js';
 import { hide, reveal } from './visibility.js';
 
 /** Identifies the replacement action on the stage; SwipeTracker uses it too. */
@@ -683,9 +683,4 @@ function previewIndex(slide, progress) {
     const to = indices[clamp(Math.ceil(progress))];
 
     return from + (to - from) * (progress - lower);
-}
-
-function monitorIndexOf(connector) {
-    return Main.layoutManager.monitors.findIndex(
-        (monitor, index) => connectorOf(monitor, index) === connector);
 }

--- a/src/slide.js
+++ b/src/slide.js
@@ -320,9 +320,22 @@ export class SlideController {
         // The overview owns the whole screen while it is up, secondary
         // monitors included. The shell already disables its tracker there, so
         // the gesture stops on its own; only a running slide needs dropping.
+        //
+        // The lock screen is the same shape of problem with a worse ending. The
+        // shield takes a modal grab, Main.actionMode becomes LOCK_SCREEN, and
+        // SwipeTracker drops events that do not match its allowed modes before
+        // it ever emits 'end'. Nothing finishes the gesture: _session stays
+        // set, so sliding is dead for the rest of the session, the cover stays
+        // on the stage, and disable_unredirect() is never balanced. Until this
+        // extension declared unlock-dialog, being disabled on lock hid that.
         this._signals = [
             [Main.overview, Main.overview.connect('showing',
                 () => this._cancel())],
+            [Main.sessionMode, Main.sessionMode.connect('updated',
+                () => {
+                    if (Main.sessionMode.isLocked)
+                        this._cancel();
+                })],
         ];
 
         this._takeOverTracker();

--- a/src/switcherPopup.js
+++ b/src/switcherPopup.js
@@ -167,6 +167,14 @@ export class SwitcherPopup {
         if (Main.overview.visible)
             return;
 
+        // Nothing this extension draws belongs on the lock screen — and this
+        // popup would land on top of it, because the shield is added as chrome
+        // while add_child() below simply appends. Reachable from there: a
+        // background app un-minimizing its own window makes the monitor follow
+        // it, and following is a switch like any other.
+        if (Main.sessionMode.isLocked)
+            return;
+
         const monitorIndex = monitorIndexOf(state.connector);
         if (monitorIndex < 0)
             return;

--- a/src/switcherPopup.js
+++ b/src/switcherPopup.js
@@ -42,7 +42,7 @@ import * as Layout from 'resource:///org/gnome/shell/ui/layout.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { ANIMATION_TIME } from 'resource:///org/gnome/shell/ui/workspaceSwitcherPopup.js';
 
-import { connectorOf } from './monitorState.js';
+import { monitorIndexOf } from './monitorState.js';
 
 /** How long the pill stays up. The shell keeps its copy private, so: duplicated. */
 const DISPLAY_TIMEOUT = 600;
@@ -197,10 +197,4 @@ export class SwitcherPopup {
 
         this._popups.clear();
     }
-}
-
-/** Current index for a connector, or -1 if that monitor is not attached. */
-function monitorIndexOf(connector) {
-    return Main.layoutManager.monitors.findIndex(
-        (monitor, index) => connectorOf(monitor, index) === connector);
 }


### PR DESCRIPTION
Closes #7
Closes #8

## Type

- [x] Bug fix — `type:bug`
- [ ] New feature — `type:feature`
- [ ] Documentation only — `type:docs`
- [ ] Refactoring — `type:refactor`
- [ ] Maintenance or tooling — `type:chore`
- [ ] Breaking change — `type:breaking-change`

## What this does

- **The arrangement survives a suspend.** Windows come back on the virtual workspace they were on, instead of every app piling into one. It survives a lock, an unplug and a dock for the same reason.
- **`Super` + mouse wheel switches workspaces on a secondary monitor**, the way it always has on the primary. The touchpad swipe already worked; the wheel took a different path through the shell and never reached us.
- **Monitors are keyed by their real connector.** They were keyed by index, despite a comment saying that is exactly what must not happen — so a display returning in a different position inherited another display's arrangement.

## Changes

| File | Change |
| --- | --- |
| `src/placement.js` | **New.** Each window carries a note — connector plus virtual workspace — under `Symbol.for('workspace-islands.placement')`. Survives `disable()`/`enable()`, which is the requirement |
| `src/scroll.js` | **New.** Sixth shell seam: `WindowManager.handleWorkspaceScroll`, so `Super` + wheel acts on the monitor under the pointer |
| `src/monitorState.js` | Real `connectorOf()` via `Meta.MonitorManager`, cached; `_place()` as the one way into a group; new `track()` priority chain; `detach()` stamps before releasing; `forPointerMonitor()`; instant `reapply`/`restoreAll` |
| `src/extension.js` | `monitors-changed` split into a synchronous release and a deferred re-adopt; `_reclaim()`; untrack by the note rather than by `forWindow()`; scroll seam wired in |
| `src/overview.js` | Guard `WorkspaceBackground` against reading a monitor that has left; `scrollDelta()` moved out to `scroll.js` |
| `src/slide.js` | Public `cancel()`; cancels on lock, which nothing else would do any more |
| `src/switcherPopup.js` | Do not draw the OSD on the lock screen |
| `src/metadata.json` | `session-modes: [user, unlock-dialog]`; `version-name` 0.1.1 |
| `src/persistence.js` | Header only — the identity limit is *across* sessions, and says where the other half lives |
| `src/indicator.js` | Comment only — the panel is not rebuilt on a session mode change in GNOME 50 |
| `README.md` | What survives a lock, an unplug and a suspend; the `Super` + wheel row; the connector claim; the second `Meta.Window` symbol |

## How it was verified

- [x] `make doctor` passes
- [x] Tested in a real session (logged out and back in — a running shell caches modules and will not pick up edits)
- [x] Tested with more than one monitor
- [x] Disabled and re-enabled the extension: no windows left minimized, no leftover panel widgets, nothing patched still patched

Suspend and resume on real hardware: confirmed fixed, which was the report in #7.

In a nested session (`make nested`, mutter-devkit), with debug logging on:

- one `monitors settled` line per hotplug, not one per emission — the burst is coalesced
- the log names a real connector (`Meta-1`), never `monitor-1`
- every seam resolves; each patch warns by name when its seam is missing, and the log is silent

Two things nested does **not** prove, and it is worth being explicit about both. Virtual displays return with a different output id, so Mutter's own `preferred_output_winsys_id` restore never fires and windows are stranded on the primary — a harder case than real hardware, and what prompted `_reclaim()`. And `Super` + wheel needs a mouse over a secondary monitor, so it was verified by reading the shell's dispatch and confirming the seam resolves, not by turning a wheel.

## Shell internals

Two new seams and one behaviour change:

**`WindowManager.handleWorkspaceScroll`** — overridden so a wheel notch over a secondary monitor switches that monitor's virtual workspace. Falls through to the original everywhere else. If the seam moves, the warning fires and `Super` + wheel goes back to only moving the primary. Notably this one is called as a live method lookup, not through a handler captured with `.bind()` at construction — the trap `slide.js` and `overview.js` each document having fallen into. That is luck, not design, and if it ever changes to `.bind()` the override will silently stop being reached.

**`WorkspaceBackground._updateRoundedClipBounds`** — returns early when the monitor index no longer resolves. This is the shell's own bug: it connects `workareas-changed` and recomputes against `Main.layoutManager.monitors[index]`, which is `undefined` once that monitor is gone. Its own `ExtraWorkspaceView` hits it once per secondary monitor, quietly enough that nobody has chased it. Worth patching from here because this extension gives a monitor one page per virtual workspace, so the same unplug throws once per page — four JS errors and a wall of allocation warnings, all pointing at shell files and none mentioning this extension.

**`session-modes: unlock-dialog`** is not a seam but changes what runs while locked, so: keybindings register `ActionMode.NORMAL` and cannot fire; the overview is unreachable; the switcher OSD and the slide both now bail on `Main.sessionMode.isLocked`. The slide guard is load-bearing — the shield's modal grab moves `Main.actionMode` to `LOCK_SCREEN` and `SwipeTracker` drops events that do not match before emitting `end`, so a slide in flight would never finish and sliding would be dead for the rest of the session. Being disabled on lock used to hide that.

One thing that will not change and should not be read as a failure: the extension is still torn down and rebuilt on every lock, because the shell rebases the extension order whenever it disables one and six `user`-only extensions sit ahead of this one. `session-modes` cannot prevent that. The notes are what make it survivable, which is why they are the fix and `session-modes` is the polish.

## Checklist

- [x] Linked an issue above
- [x] Exactly one `type:*` label
- [x] Conventional commit messages
- [x] README updated if behaviour changed
