### PR TITLE
feat: add dynamic virtual workspaces per monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,10 @@ gnome-extensions prefs workspace-islands@danielbernalo.github.io
 
 | Option | Default | What it does |
 | --- | --- | --- |
-| **Workspaces per monitor** | `4` | How many workspaces each secondary monitor gets. Range 2–8. Applies to every secondary monitor; the primary keeps using GNOME's own. |
+| **Dynamic workspaces** | off | Each secondary monitor grows its own workspaces as they fill up and shrinks them back down as they empty, with no maximum — matching GNOME's own dynamic workspaces. Always keeps one empty workspace in reserve; an empty one elsewhere collapses too, unless it's the one you're on. |
+| **Workspaces per monitor** | `4` | The fixed number of workspaces each secondary monitor gets. Range 2–8. Only applies while Dynamic workspaces is off — greyed out otherwise. |
 
-Lowering the count folds everything beyond the new end into the last workspace rather than losing those windows.
+Lowering the count folds everything beyond the new end into the last workspace rather than losing those windows. Turning Dynamic workspaces on or off never changes what this setting means; it only decides whether the fixed count is enforced.
 
 ### Switching
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -32,6 +32,14 @@ const ONLY_ON_PRIMARY = 'workspaces-only-on-primary';
 const PAPERWM_UUID = 'paperwm@paperwm.github.com';
 
 /**
+ * The schema only defines `switch-to-1` through `switch-to-8` — the same
+ * ceiling `prefs.js`'s shortcut list assumes. In dynamic mode there is no
+ * setting to read a smaller number from (the static count is irrelevant and
+ * greyed out in prefs), so this is the count to bind up to instead.
+ */
+const MAX_DIRECT_SWITCH_KEYS = 8;
+
+/**
  * How long to wait for the monitor layout to stop moving.
  *
  * `monitors-changed` is not one event. A resume or a DP-MST dock emits it two
@@ -357,6 +365,12 @@ export default class WorkspaceIslands extends Extension {
 
         this._connect(this._settings, 'changed::dynamic-virtual-workspaces', () => {
             this._registry.setDynamic(this._settings.get_boolean('dynamic-virtual-workspaces'));
+
+            // _bindKeys() reads this same setting to decide how many
+            // switch-to-N keys to register, so the toggle needs the same
+            // rebind the virtual-workspaces handler above already does.
+            this._keys.removeAll();
+            this._bindKeys();
             this._afterChange('dynamic workspaces toggled');
         });
     }
@@ -558,12 +572,21 @@ export default class WorkspaceIslands extends Extension {
     }
 
     _bindKeys() {
-        const count = this._settings.get_int('virtual-workspaces');
+        // Dynamic mode has no setting to cap this at — the static count is
+        // irrelevant and greyed out in prefs — so bind up to the schema's own
+        // ceiling instead of whatever the (unrelated) static count is left at.
+        const count = this._settings.get_boolean('dynamic-virtual-workspaces')
+            ? MAX_DIRECT_SWITCH_KEYS
+            : this._settings.get_int('virtual-workspaces');
 
-        // Only up to `count`: the remaining schema keys default to an empty
-        // accelerator list, and registering those just logs noise.
-        for (let i = 1; i <= count; i++)
-            this._keys.add(`switch-to-${i}`, () => this._switchTo(i - 1));
+        // Only where an accelerator is actually set: switch-to-5..8 default to
+        // an empty list, and registering those anyway just logs noise for a
+        // shortcut nobody asked for.
+        for (let i = 1; i <= count; i++) {
+            const name = `switch-to-${i}`;
+            if (this._settings.get_strv(name).length > 0)
+                this._keys.add(name, () => this._switchTo(i - 1));
+        }
 
         this._keys.add('switch-next', () => this._switchRelative(1));
         this._keys.add('switch-prev', () => this._switchRelative(-1));

--- a/src/extension.js
+++ b/src/extension.js
@@ -64,6 +64,7 @@ export default class WorkspaceIslands extends Extension {
 
         this._registry = new Registry(
             this._settings.get_int('virtual-workspaces'),
+            this._settings.get_boolean('dynamic-virtual-workspaces'),
             this._persistence.load()
         );
         this._registry.syncMonitors();
@@ -78,9 +79,14 @@ export default class WorkspaceIslands extends Extension {
         this._adoptExistingWindows();
 
         // Existing windows were adopted against the restored active index, so
-        // bring the screen in line with it before anyone looks at it.
-        for (const state of this._registry.states)
+        // bring the screen in line with it before anyone looks at it. Also
+        // reconciles size: a saved arrangement can grow a state to fit indices
+        // it doesn't have windows for this session, leaving trailing empties
+        // dynamic mode never got a chance to trim reactively.
+        for (const state of this._registry.states) {
             state.reapply();
+            state.reconcileSize();
+        }
 
         this._connectSignals();
         this._bindKeys();
@@ -343,10 +349,15 @@ export default class WorkspaceIslands extends Extension {
         });
 
         this._connect(this._settings, 'changed::virtual-workspaces', () => {
-            this._registry.resize(this._settings.get_int('virtual-workspaces'));
+            this._registry.setFixedCount(this._settings.get_int('virtual-workspaces'));
             this._keys.removeAll();
             this._bindKeys();
             this._afterChange('workspace count changed');
+        });
+
+        this._connect(this._settings, 'changed::dynamic-virtual-workspaces', () => {
+            this._registry.setDynamic(this._settings.get_boolean('dynamic-virtual-workspaces'));
+            this._afterChange('dynamic workspaces toggled');
         });
     }
 
@@ -407,8 +418,10 @@ export default class WorkspaceIslands extends Extension {
             reclaimed += this._reclaim(connector);
 
         this._adoptExistingWindows();
-        for (const state of this._registry.states)
+        for (const state of this._registry.states) {
             state.reapply();
+            state.reconcileSize();
+        }
 
         // Last, not first. Everything above travels through
         // window-entered-monitor, which reads this flag to tell a relocation

--- a/src/extension.js
+++ b/src/extension.js
@@ -301,6 +301,11 @@ export default class WorkspaceIslands extends Extension {
             const connector = placementConnector(window);
             if (connector)
                 this._registry.forConnector(connector)?.untrack(window);
+
+            // untrack() can shrink the monitor in dynamic mode, which the
+            // panel dots need to hear about the same way _trackWindow() and
+            // the 'unmanaged' handler already tell them about a change.
+            this._indicator?.sync();
         });
 
         // Mutter announces a layout change before it applies one, and it moves
@@ -651,9 +656,13 @@ export default class WorkspaceIslands extends Extension {
         if (announce)
             this._popup?.show(state);
 
+        // Not `index`: switchTo() can have just collapsed an empty workspace
+        // and shifted everything after it, including the one just landed on
+        // — activeIndex is the one value guaranteed to still name it, same
+        // reasoning as the slide.js fix for the same underlying cause.
         this._afterChange(
-            `${state.connector} -> virtual workspace ${index + 1} ` +
-            `(${state.windowsOn(index).length} window(s))`);
+            `${state.connector} -> virtual workspace ${state.activeIndex + 1} ` +
+            `(${state.activeWindows.length} window(s))`);
     }
 
     /** Single place where a state change is persisted, shown and logged. */

--- a/src/monitorState.js
+++ b/src/monitorState.js
@@ -73,22 +73,19 @@ export class MonitorState {
     }
 
     /**
-     * Restore a previously saved arrangement. Indices are clamped, not trusted.
+     * Restore a previously saved arrangement. Indices are clamped, not
+     * trusted — `apps` comes straight out of a JSON blob in gsettings, and
+     * nothing about its shape is validated beyond "is this an object". A
+     * corrupted or hand-edited value naming an enormous index must not turn
+     * into an enormous `resize()`, so this never grows to fit anything; it
+     * only ever clamps into whatever size the monitor already is.
      *
-     * Grows to fit app rules first: a monitor starts at {@link MIN_SIZE}
-     * regardless of mode, so a saved rule pointing at workspace 5 would
-     * otherwise collapse to whatever the floor is before the app it predicts
-     * ever gets a chance to reopen there. `activeIndex` alone does not force
-     * growth — it says only where the user was looking last time, not that
-     * anything lives there, and a static-mode restore is finalised by the
-     * unconditional resize to the fixed count right after this call anyway.
+     * That size is `Registry`'s to have gotten right before calling this —
+     * see `_createState()`, which sizes a fixed-mode monitor to its
+     * configured count *first* so a rule within that range clamps to its
+     * real slot rather than to whatever the floor happens to be.
      */
     restore({ activeIndex = 0, apps = {} } = {}) {
-        const appIndices = Object.values(apps).filter(Number.isInteger);
-        const needed = appIndices.length ? Math.max(...appIndices) + 1 : 0;
-        if (needed > this.size)
-            this.resize(needed);
-
         this.activeIndex = clamp(activeIndex, 0, this.size - 1);
 
         this._appRules = new Map(
@@ -500,15 +497,17 @@ export class Registry {
     _createState(connector) {
         const state = new MonitorState(connector, this._dynamic);
 
+        // Fixed mode: size to the configured count *before* restoring, not
+        // after — restore() only clamps, so a saved rule within that count
+        // has to find the real size already in place or it clamps down to
+        // the floor and stays there. Dynamic mode never force-grows — size
+        // is earned by occupancy from here on.
+        if (!this._dynamic)
+            state.resize(this._fixedCount);
+
         const saved = this._saved?.monitors?.[connector];
         if (saved)
             state.restore(saved);
-
-        // Fixed mode: bring a freshly-created (or partially grown-to-fit-saved-
-        // data) state up to the exact configured count, same as always. Dynamic
-        // mode never force-grows — size is earned by occupancy from here on.
-        if (!this._dynamic)
-            state.resize(this._fixedCount);
 
         this._states.set(connector, state);
         return state;

--- a/src/monitorState.js
+++ b/src/monitorState.js
@@ -22,12 +22,49 @@ import { hide, show, isHiddenByUs } from './visibility.js';
 import { appKeyOf } from './persistence.js';
 import { stamp, placementIndex } from './placement.js';
 
+/**
+ * Every monitor keeps at least this many virtual workspaces, dynamic or not.
+ *
+ * Below 2, `overview.js` and `slide.js` fall back to treating the monitor as
+ * having no virtual workspaces at all (plain overview, no swipe) — a floor of
+ * 2 keeps that branch permanently unreachable instead of needing the monitor's
+ * overview to swap view types live as it shrinks and grows.
+ */
+const MIN_SIZE = 2;
+
 export class MonitorState {
-    constructor(connector, size) {
+    /**
+     * @param {string} connector
+     * @param {boolean} [dynamic] grow/shrink with occupancy instead of
+     *   staying at whatever count `Registry` applies externally
+     */
+    constructor(connector, dynamic = false) {
         this.connector = connector;
         this.activeIndex = 0;
-        this._groups = Array.from({ length: size }, () => new Set());
+        this._dynamic = dynamic;
+        this._groups = Array.from({ length: MIN_SIZE }, () => new Set());
         this._appRules = new Map();
+        this._sizeListeners = new Set();
+    }
+
+    setDynamic(dynamic) {
+        this._dynamic = dynamic;
+    }
+
+    /**
+     * Notified whenever `size` actually changes.
+     *
+     * @param {() => void} callback
+     * @returns {() => void} unsubscribe
+     */
+    onSizeChanged(callback) {
+        this._sizeListeners.add(callback);
+        return () => this._sizeListeners.delete(callback);
+    }
+
+    _notifySizeChanged() {
+        for (const listener of this._sizeListeners)
+            listener();
     }
 
     /** Plain object for serialisation: WM_CLASS -> virtual workspace index. */
@@ -35,8 +72,23 @@ export class MonitorState {
         return Object.fromEntries(this._appRules);
     }
 
-    /** Restore a previously saved arrangement. Indices are clamped, not trusted. */
+    /**
+     * Restore a previously saved arrangement. Indices are clamped, not trusted.
+     *
+     * Grows to fit app rules first: a monitor starts at {@link MIN_SIZE}
+     * regardless of mode, so a saved rule pointing at workspace 5 would
+     * otherwise collapse to whatever the floor is before the app it predicts
+     * ever gets a chance to reopen there. `activeIndex` alone does not force
+     * growth — it says only where the user was looking last time, not that
+     * anything lives there, and a static-mode restore is finalised by the
+     * unconditional resize to the fixed count right after this call anyway.
+     */
     restore({ activeIndex = 0, apps = {} } = {}) {
+        const appIndices = Object.values(apps).filter(Number.isInteger);
+        const needed = appIndices.length ? Math.max(...appIndices) + 1 : 0;
+        if (needed > this.size)
+            this.resize(needed);
+
         this.activeIndex = clamp(activeIndex, 0, this.size - 1);
 
         this._appRules = new Map(
@@ -154,6 +206,7 @@ export class MonitorState {
             target = this.activeIndex;
 
         this._place(window, target);
+        this._growIfNeeded(target);
 
         if (target !== this.activeIndex)
             hide(window);
@@ -162,8 +215,13 @@ export class MonitorState {
     }
 
     untrack(window) {
+        const from = this.indexOf(window);
+
         for (const group of this._groups)
             group.delete(window);
+
+        if (from !== -1)
+            this._reconcileEmpties();
     }
 
     /**
@@ -183,6 +241,13 @@ export class MonitorState {
             hide(window, { animate });
 
         this.activeIndex = index;
+
+        // The workspace just left may have been empty and is no longer
+        // protected by being active — exactly what makes it removable now,
+        // the same way native GNOME drops an empty workspace once you switch
+        // away from it.
+        this._reconcileEmpties();
+
         return true;
     }
 
@@ -196,6 +261,7 @@ export class MonitorState {
 
         this._groups[from].delete(window);
         this._place(window, index);
+        this._growIfNeeded(index);
 
         // Moving a window by hand is the strongest signal we get about where
         // its application belongs, so it updates the rule.
@@ -205,6 +271,9 @@ export class MonitorState {
             show(window);
         else
             hide(window);
+
+        // The group it left behind, not the one it joined — that one just grew.
+        this._reconcileEmpties();
 
         return true;
     }
@@ -290,37 +359,137 @@ export class MonitorState {
 
     /** Resize the workspace count, folding anything beyond the new end. */
     resize(size) {
-        if (size === this.size || size < 1)
+        if (size === this.size || size < MIN_SIZE)
             return;
 
         if (size > this.size) {
             while (this._groups.length < size)
                 this._groups.push(new Set());
+        } else {
+            // Shrinking: everything past the new end collapses into the last
+            // group rather than vanishing along with its windows.
+            const tail = this._groups.splice(size);
+            for (const group of tail) {
+                for (const window of group)
+                    this._place(window, size - 1);
+            }
+
+            if (this.activeIndex >= size)
+                this.activeIndex = size - 1;
+
+            // Rules pointing past the new end would silently send windows nowhere.
+            for (const [key, index] of this._appRules) {
+                if (index >= size)
+                    this._appRules.set(key, size - 1);
+            }
+        }
+
+        this._notifySizeChanged();
+    }
+
+    /**
+     * Grow by one if the group a window just landed in was the last one.
+     *
+     * Only in dynamic mode, and with no ceiling — the same shape as GNOME's
+     * own dynamic workspaces always keeping one empty one in reserve.
+     */
+    _growIfNeeded(index) {
+        if (this._dynamic && index === this.size - 1)
+            this.resize(this.size + 1);
+    }
+
+    /**
+     * Remove every empty group except the active one and the last one,
+     * shifting later indices down to fill the gap.
+     *
+     * Only in dynamic mode. Matches native GNOME dynamic workspaces: an empty
+     * workspace disappears unless it's the one you're looking at (removing
+     * that out from under you would be jarring) or the trailing spare (always
+     * kept in reserve). A no-op if nothing qualifies, so it is cheap to call
+     * after anything that might have emptied a group.
+     */
+    _reconcileEmpties() {
+        if (!this._dynamic)
             return;
+
+        const lastIndex = this.size - 1;
+        const removable = [];
+        for (let i = 0; i < this.size; i++) {
+            if (i === this.activeIndex || i === lastIndex)
+                continue;
+            if (this._groups[i].size === 0)
+                removable.push(i);
+        }
+        if (removable.length === 0)
+            return;
+
+        // Never below the floor, even if that means leaving some empty
+        // slots in place — see MIN_SIZE.
+        const toRemove = new Set(removable.slice(0, Math.max(0, this.size - MIN_SIZE)));
+        if (toRemove.size === 0)
+            return;
+
+        // Re-stamp windows whose index changed as each slot is kept, so a
+        // future reclaim/restore agrees with where they actually ended up —
+        // _place() is the only other writer of this note, and it isn't
+        // involved in a pure re-index.
+        const oldToNew = new Map();
+        const newGroups = [];
+        for (let i = 0; i < this.size; i++) {
+            if (toRemove.has(i))
+                continue;
+
+            const newIndex = newGroups.length;
+            oldToNew.set(i, newIndex);
+            newGroups.push(this._groups[i]);
+
+            if (i !== newIndex) {
+                for (const window of this._groups[i])
+                    stamp(window, this.connector, newIndex);
+            }
         }
 
-        // Shrinking: everything past the new end collapses into the last group
-        // rather than vanishing along with its windows.
-        const tail = this._groups.splice(size);
-        for (const group of tail) {
-            for (const window of group)
-                this._place(window, size - 1);
-        }
+        this._groups = newGroups;
+        this.activeIndex = oldToNew.get(this.activeIndex);
 
-        if (this.activeIndex >= size)
-            this.activeIndex = size - 1;
-
-        // Rules pointing past the new end would silently send windows nowhere.
-        for (const [key, index] of this._appRules) {
-            if (index >= size)
-                this._appRules.set(key, size - 1);
+        // A rule pointing at a slot that just got removed for being empty
+        // loses its home — dropped, the same way a stale rule a shrink can't
+        // reach is already dropped today, rather than remapped to somewhere
+        // it never asked for.
+        const newAppRules = new Map();
+        for (const [key, oldIndex] of this._appRules) {
+            if (oldToNew.has(oldIndex))
+                newAppRules.set(key, oldToNew.get(oldIndex));
         }
+        this._appRules = newAppRules;
+
+        this._notifySizeChanged();
+    }
+
+    /**
+     * Re-establish the dynamic-mode empty-workspace invariant after something
+     * that changes membership without going through
+     * track()/untrack()/moveWindowTo()/switchTo() — a restore that grew to
+     * fit saved data, or a hotplug that reclaimed some windows but not
+     * others. Safe to call unconditionally; a no-op outside dynamic mode or
+     * when the invariant already holds.
+     */
+    reconcileSize() {
+        this._reconcileEmpties();
     }
 }
 
 export class Registry {
-    constructor(size, saved = { monitors: {} }) {
-        this._size = size;
+    /**
+     * @param {number} fixedCount the exact count applied when not dynamic;
+     *   has no effect on a monitor currently in dynamic mode, which grows
+     *   without a ceiling
+     * @param {boolean} dynamic
+     * @param {object} [saved]
+     */
+    constructor(fixedCount, dynamic, saved = { monitors: {} }) {
+        this._fixedCount = fixedCount;
+        this._dynamic = dynamic;
         this._states = new Map();
 
         // Kept around rather than applied once: a monitor plugged in later in
@@ -329,18 +498,24 @@ export class Registry {
     }
 
     _createState(connector) {
-        const state = new MonitorState(connector, this._size);
+        const state = new MonitorState(connector, this._dynamic);
 
         const saved = this._saved?.monitors?.[connector];
         if (saved)
             state.restore(saved);
 
+        // Fixed mode: bring a freshly-created (or partially grown-to-fit-saved-
+        // data) state up to the exact configured count, same as always. Dynamic
+        // mode never force-grows — size is earned by occupancy from here on.
+        if (!this._dynamic)
+            state.resize(this._fixedCount);
+
         this._states.set(connector, state);
         return state;
     }
 
-    get size() {
-        return this._size;
+    get fixedCount() {
+        return this._fixedCount;
     }
 
     get states() {
@@ -372,10 +547,39 @@ export class Registry {
         return live;
     }
 
-    resize(size) {
-        this._size = size;
+    /**
+     * Change the static-mode count.
+     *
+     * Applied immediately only to monitors currently in fixed mode. A
+     * dynamic monitor has no ceiling to change — the new value is just
+     * remembered for whenever fixed mode resumes on it.
+     */
+    setFixedCount(count) {
+        this._fixedCount = count;
+        if (this._dynamic)
+            return;
+
         for (const state of this._states.values())
-            state.resize(size);
+            state.resize(count);
+    }
+
+    /**
+     * Switch every monitor between fixed and dynamic.
+     *
+     * Fixed -> dynamic: trims any excess trailing empties, but does not
+     * force-grow anything — growth resumes organically from here.
+     * Dynamic -> fixed: forces every monitor to the exact configured count,
+     * identical to a plain count change today.
+     */
+    setDynamic(dynamic) {
+        this._dynamic = dynamic;
+        for (const state of this._states.values()) {
+            state.setDynamic(dynamic);
+            if (dynamic)
+                state.reconcileSize();
+            else
+                state.resize(this._fixedCount);
+        }
     }
 
     forConnector(connector) {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -56,6 +56,16 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
                 'one. The primary monitor keeps using GNOME’s own workspaces.'),
         });
 
+        const dynamic = new Adw.SwitchRow({
+            title: _('Dynamic workspaces'),
+            subtitle: _('Each monitor grows and shrinks its own workspaces as ' +
+                'they fill up and empty, with no maximum, always keeping one ' +
+                'empty one ready — like GNOME’s own dynamic workspaces.'),
+        });
+        settings.bind('dynamic-virtual-workspaces', dynamic, 'active',
+            Gio.SettingsBindFlags.DEFAULT);
+        group.add(dynamic);
+
         const count = new Adw.SpinRow({
             title: _('Workspaces per monitor'),
             adjustment: new Gtk.Adjustment({
@@ -67,6 +77,10 @@ export default class WorkspaceIslandsPreferences extends ExtensionPreferences {
         });
         settings.bind('virtual-workspaces', count, 'value',
             Gio.SettingsBindFlags.DEFAULT);
+        // Only applies with dynamic workspaces off — greyed out otherwise
+        // rather than left looking like it still does something.
+        settings.bind('dynamic-virtual-workspaces', count, 'sensitive',
+            Gio.SettingsBindFlags.INVERT_BOOLEAN);
         group.add(count);
 
         page.add(group);

--- a/src/schemas/org.gnome.shell.extensions.workspace-islands.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.workspace-islands.gschema.xml
@@ -4,6 +4,17 @@
   <schema id="org.gnome.shell.extensions.workspace-islands"
           path="/org/gnome/shell/extensions/workspace-islands/">
 
+    <key name="dynamic-virtual-workspaces" type="b">
+      <default>false</default>
+      <summary>Grow and shrink virtual workspaces automatically</summary>
+      <description>
+        Each secondary monitor grows its own virtual workspaces as they fill up
+        and shrinks them back down as they empty, always keeping one empty
+        workspace ready at the end — like GNOME's own dynamic workspaces. When
+        off, every monitor uses the fixed count below instead.
+      </description>
+    </key>
+
     <key name="virtual-workspaces" type="i">
       <default>4</default>
       <range min="2" max="8"/>

--- a/src/slide.js
+++ b/src/slide.js
@@ -191,6 +191,18 @@ class IslandsSlidePage extends Clutter.Actor {
  *
  * `progress` is a GObject property so it can be eased and bound — which is what
  * lets a swipe and a keypress drive the identical code path.
+ *
+ * Known gap: `_pages` captures workspace indices once, at gesture start, and
+ * never revisits them. In dynamic mode a window closing mid-gesture can fire
+ * `untrack()` -> `MonitorState._reconcileEmpties()`, which renumbers every
+ * workspace after the one it collapses — underneath a slide already holding
+ * the old numbers. `SlideController._finish()` reads `state.activeIndex`
+ * fresh at commit time, so the *landing* workspace is always right, but a
+ * gesture already in flight is still animating against stale indices for
+ * whichever pages it prepared before that. Fixing this for real would mean
+ * subscribing to `state.onSizeChanged()` for the life of the gesture and
+ * re-mapping `indices` through the same kind of old-to-new translation
+ * `_reconcileEmpties()` builds internally — which isn't exposed today.
  */
 const Slide = GObject.registerClass({
     Properties: {

--- a/src/slide.js
+++ b/src/slide.js
@@ -556,7 +556,13 @@ export class SlideController {
         this._claimed = false;
 
         this._onCommit(session.state, index, { gesture: session.gesture });
-        this._settle(session, index);
+
+        // Not `index`: onCommit's switchTo() may have just collapsed an empty
+        // workspace and shifted everything after it, including the one we
+        // landed on. state.activeIndex is the one value guaranteed to still
+        // point at it — session.state.indexOf() below has to agree with the
+        // same numbering, or a page that's actually current gets re-hidden.
+        this._settle(session, session.state.activeIndex);
         this._teardown(session);
     }
 

--- a/src/workspacesView.js
+++ b/src/workspacesView.js
@@ -243,19 +243,11 @@ class IslandsThumbnails extends St.Widget {
 
         this._monitor = monitor;
         this._state = state;
+        this._onActivate = onActivate;
+        this._onDrop = onDrop;
 
         this._thumbnails = [];
-
-        for (let index = 0; index < state.size; index++) {
-            const thumbnail = new Thumbnail(monitor, state, index, onDrop);
-
-            const click = new Clutter.ClickGesture();
-            click.connect('recognize', () => onActivate(index));
-            thumbnail.add_action(click);
-
-            this.add_child(thumbnail);
-            this._thumbnails.push(thumbnail);
-        }
+        this._buildThumbnails();
 
         // A separate actor rather than a border on the active thumbnail: it is
         // how the shell draws it, and it can be moved without a restyle.
@@ -267,10 +259,43 @@ class IslandsThumbnails extends St.Widget {
         this.setActive(state.activeIndex);
     }
 
-    /** Re-read the model. A drop moved a window between two of these. */
-    refresh() {
-        this._thumbnails.forEach(
-            (thumbnail, index) => thumbnail.setWindows(this._state.windowsOn(index)));
+    /**
+     * Below `this._indicator` when it already exists, so a rebuild does not
+     * repaint the fresh thumbnails on top of it — the indicator is a border
+     * overlay and has to stay the topmost child. Not yet built the first
+     * time this runs, from the constructor, so a plain append is right there.
+     */
+    _buildThumbnails() {
+        for (let index = 0; index < this._state.size; index++) {
+            const thumbnail = new Thumbnail(this._monitor, this._state, index, this._onDrop);
+
+            const click = new Clutter.ClickGesture();
+            click.connect('recognize', () => this._onActivate(index));
+            thumbnail.add_action(click);
+
+            if (this._indicator)
+                this.insert_child_below(thumbnail, this._indicator);
+            else
+                this.add_child(thumbnail);
+            this._thumbnails.push(thumbnail);
+        }
+    }
+
+    /**
+     * Destroy and recreate every thumbnail from the current `state.size`.
+     *
+     * Mirrors the constructor's own loop; a straightforward destroy-and-
+     * recreate is enough because a workspace count change is an infrequent,
+     * human-scale event, not a per-frame one.
+     */
+    rebuild() {
+        for (const thumbnail of this._thumbnails)
+            thumbnail.destroy();
+
+        this._thumbnails = [];
+        this._buildThumbnails();
+
+        this.setActive(this._state.activeIndex);
     }
 
     setActive(index) {
@@ -388,11 +413,17 @@ class IslandsWorkspacesView extends ExtraWorkspaceView {
             (...args) => this._drop(...args));
         this.add_child(this._thumbnails);
 
+        // Growth/shrink can happen at any time in dynamic mode, not just after
+        // a drop — a page or thumbnail appearing/disappearing needs the same
+        // rebuild, just triggered reactively instead of from _drop().
+        this._unsubscribeSize = state.onSizeChanged(() => this._scheduleRefresh());
+
         this.connect('destroy', () => {
             if (this._refreshId) {
                 GLib.Source.remove(this._refreshId);
                 this._refreshId = 0;
             }
+            this._unsubscribeSize?.();
         });
 
         this._updateWorkspacesState();
@@ -409,14 +440,22 @@ class IslandsWorkspacesView extends ExtraWorkspaceView {
      */
     _drop(index, window, monitorIndex) {
         this._onDrop(index, window, monitorIndex);
+        this._scheduleRefresh();
+    }
 
+    /**
+     * Coalesce any number of drops/size-changes within one main loop turn into
+     * a single rebuild that reads the final state — a burst of growth/shrink
+     * from rapid open/close only costs one rebuild, not one per event.
+     */
+    _scheduleRefresh() {
         if (this._refreshId)
             return;
 
         this._refreshId = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
             this._refreshId = 0;
             this._rebuildPages();
-            this._thumbnails.refresh();
+            this._thumbnails.rebuild();
             return GLib.SOURCE_REMOVE;
         });
     }
@@ -441,6 +480,11 @@ class IslandsWorkspacesView extends ExtraWorkspaceView {
         // The first page stands in for `this._workspace`, which the parent
         // class still reaches for in _updateWorkspaceMode.
         this._workspace = this._pages[0];
+
+        // Only ever read at construction until now, because a drop never
+        // changed page count. Structural size changes do, so the scroll
+        // range has to move in lock-step with the rebuilt page list.
+        this._scrollAdjustment.upper = this._state.size;
 
         this._updateWorkspacesState();
         this.queue_relayout();

--- a/src/workspacesView.js
+++ b/src/workspacesView.js
@@ -483,8 +483,13 @@ class IslandsWorkspacesView extends ExtraWorkspaceView {
 
         // Only ever read at construction until now, because a drop never
         // changed page count. Structural size changes do, so the scroll
-        // range has to move in lock-step with the rebuilt page list.
+        // range has to move in lock-step with the rebuilt page list — and
+        // `value` has to move with it: a collapse can shift `activeIndex`
+        // out from under a `value` that's still in range, which leaves the
+        // pages showing one workspace while the thumbnail strip highlights
+        // another.
         this._scrollAdjustment.upper = this._state.size;
+        this._scrollAdjustment.value = this._state.activeIndex;
 
         this._updateWorkspacesState();
         this.queue_relayout();


### PR DESCRIPTION
Closes #

## Type

<!-- Exactly one, and add the matching type:* label. -->

- [x] New feature — `type:feature`

Issue raised: https://github.com/danielbernalo/gnome-workspace-islands/issues/11

## What this does

- Each secondary monitor can grow its own virtual workspaces as they fill up
  and shrink them back down as they empty, instead of always holding a fixed
  count — an opt-in "Dynamic workspaces" toggle in preferences, off by default.
- An empty workspace collapses unless it's the active one or the trailing
  spare kept in reserve, matching GNOME's own dynamic workspaces.
- Fixes the slide animation showing an empty desktop right after landing on a
  workspace whose position had just shifted because a workspace to its left
  collapsed.

## Changes

| File | Change |
| --- | --- |
| `src/monitorState.js` | Core grow/shrink/reconcile mechanism; `Registry` splits fixed-count and dynamic modes |
| `src/extension.js` | Wire the new setting; reconcile empties after (re-)adopting windows |
| `src/workspacesView.js` | Overview now reacts live to a workspace count that changes at any time, not just after a drop |
| `src/prefs.js` | New "Dynamic workspaces" toggle; static count greyed out while it's on |
| `src/schemas/org.gnome.shell.extensions.workspace-islands.gschema.xml` | New `dynamic-virtual-workspaces` key |
| `src/slide.js` | Use `state.activeIndex` instead of a index that can go stale mid-slide |

## How it was verified

<!-- This extension has no automated tests. Say what you actually did. -->

- [x] `make doctor` passes
- [x] Tested in a real session (logged out and back in — a running shell
      caches modules and will not pick up edits)
- [x] Tested with more than one monitor
- [x] Disabled and re-enabled the extension: no windows left minimized, no
      leftover panel widgets, nothing patched still patched

## Checklist

- [X] Linked an issue above
- [x] Exactly one `type:*` label
- [x] Conventional commit messages
- [x] README updated if behaviour changed